### PR TITLE
feat: copy-paste agent connect prompt generator

### DIFF
--- a/PROJECT_DETAILS.md
+++ b/PROJECT_DETAILS.md
@@ -59,6 +59,7 @@ app/
 ├── lib/auth.js                # NextAuth config (GitHub + Google, JWT, user upsert)
 ├── lib/billing.js             # Cost estimation (tokens -> USD)
 ├── lib/usage.js               # Usage meters + quota checks
+├── lib/connectPrompt.js       # Generates markdown connect prompt for agent sessions
 ├── lib/colors.js              # Agent color hashing, action type icon map
 ├── lib/audit.js               # Fire-and-forget activity logging (logActivity)
 ├── lib/signals.js             # Shared signal computation (computeSignals)
@@ -72,6 +73,7 @@ app/
 │   ├── NotificationCenter.js  # Alert bell + notification dropdown
 │   ├── DraggableDashboard.js  # Fixed 4-column widget grid (+ onboarding checklist)
 │   ├── OnboardingChecklist.js # 4-step guided onboarding (workspace, key, SDK, first action)
+│   ├── ConnectAgentButton.js  # One-click copy-paste agent connect prompt generator
 │   ├── WaitlistForm.js        # Email capture form (client component)
 │   ├── SecurityDetailPanel.js  # Slide-out detail drawer (signal + action detail)
 │   ├── AssumptionGraph.js     # SVG+HTML trace visualization (parent chain, assumptions, loops)

--- a/app/api-keys/page.js
+++ b/app/api-keys/page.js
@@ -8,6 +8,7 @@ import { Card, CardContent } from '../components/ui/Card';
 import { Badge } from '../components/ui/Badge';
 import { StatCompact } from '../components/ui/Stat';
 import { EmptyState } from '../components/ui/EmptyState';
+import ConnectAgentButton from '../components/ConnectAgentButton';
 
 export default function ApiKeysPage() {
   const { data: session } = useSession();
@@ -178,15 +179,18 @@ export default function ApiKeysPage() {
       subtitle="Manage your workspace API keys"
       breadcrumbs={['Dashboard', 'API Keys']}
       actions={
-        isAdmin ? (
-          <button
-            onClick={() => { setShowCreateForm(true); setNewKey(null); }}
-            className="flex items-center gap-1.5 px-3 py-2 bg-brand hover:bg-brand/90 text-white text-sm font-medium rounded-lg transition-colors"
-          >
-            <Plus size={14} />
-            Generate New Key
-          </button>
-        ) : null
+        <div className="flex items-center gap-2">
+          <ConnectAgentButton />
+          {isAdmin && (
+            <button
+              onClick={() => { setShowCreateForm(true); setNewKey(null); }}
+              className="flex items-center gap-1.5 px-3 py-2 bg-brand hover:bg-brand/90 text-white text-sm font-medium rounded-lg transition-colors"
+            >
+              <Plus size={14} />
+              Generate New Key
+            </button>
+          )}
+        </div>
       }
     >
       {/* Error banner */}
@@ -219,6 +223,7 @@ export default function ApiKeysPage() {
                     {copied ? <Check size={14} className="text-green-400" /> : <Copy size={14} />}
                     {copied ? 'Copied' : 'Copy'}
                   </button>
+                  <ConnectAgentButton className="flex-shrink-0" />
                 </div>
               </div>
               <button

--- a/app/components/ConnectAgentButton.js
+++ b/app/components/ConnectAgentButton.js
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import { Terminal, Check } from 'lucide-react';
+import { generateConnectPrompt } from '../lib/connectPrompt';
+
+export default function ConnectAgentButton({ className = '', label = 'Copy Agent Prompt' }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleClick = async () => {
+    try {
+      const baseUrl = window.location.origin;
+      let orgName = 'My Workspace';
+      try {
+        const res = await fetch('/api/team');
+        if (res.ok) {
+          const data = await res.json();
+          orgName = data.org?.name || data.name || orgName;
+        }
+      } catch {
+        // Fall back to default name
+      }
+      const prompt = generateConnectPrompt(baseUrl, orgName);
+      await navigator.clipboard.writeText(prompt);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard not available
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className={`flex items-center gap-1.5 px-3 py-2 bg-surface-tertiary border border-[rgba(255,255,255,0.06)] rounded-lg text-sm text-zinc-300 hover:text-white hover:border-[rgba(255,255,255,0.12)] transition-colors ${className}`}
+    >
+      {copied ? <Check size={14} className="text-green-400" /> : <Terminal size={14} />}
+      {copied ? 'Copied!' : label}
+    </button>
+  );
+}

--- a/app/components/OnboardingChecklist.js
+++ b/app/components/OnboardingChecklist.js
@@ -5,6 +5,7 @@ import { Building2, KeyRound, Terminal, Rocket, CheckCircle2, Copy, Check, Alert
 import { Card, CardContent } from './ui/Card';
 import { ProgressBar } from './ui/ProgressBar';
 import { Badge } from './ui/Badge';
+import ConnectAgentButton from './ConnectAgentButton';
 
 const STEPS = [
   { id: 'workspace', label: 'Create your workspace', icon: Building2 },
@@ -336,6 +337,7 @@ await claw.createAction({
                   copied={copied}
                   onCopy={copyToClipboard}
                 />
+                <ConnectAgentButton label="Copy Full Setup Prompt" />
               </div>
             )}
           </StepRow>

--- a/app/lib/connectPrompt.js
+++ b/app/lib/connectPrompt.js
@@ -1,0 +1,79 @@
+/**
+ * Generates a markdown prompt users can paste into any AI agent session
+ * to self-configure a connection to their DashClaw dashboard.
+ */
+export function generateConnectPrompt(baseUrl, orgName) {
+  return `# DashClaw Agent Setup
+
+DashClaw is your AI agent observability and governance dashboard — it tracks actions, decisions, goals, and security signals.
+
+- **Dashboard**: ${baseUrl}/dashboard
+- **Workspace**: ${orgName}
+
+## 1. Set your API key
+
+Before doing anything else, set \`DASHCLAW_API_KEY\` in your environment (shell, \`.env\`, etc.).
+Do NOT paste the key into this chat.
+
+\`\`\`bash
+export DASHCLAW_API_KEY="<your-key>"
+\`\`\`
+
+## 2. Install the SDK
+
+\`\`\`bash
+# Node.js
+npm install dashclaw
+
+# Python
+pip install dashclaw
+\`\`\`
+
+## 3. Initialize the client
+
+\`\`\`js
+import { DashClaw } from 'dashclaw';
+
+const claw = new DashClaw({
+  baseUrl: '${baseUrl}',
+  apiKey: process.env.DASHCLAW_API_KEY,
+  agentId: 'my-agent',
+  agentName: 'My Agent',
+});
+\`\`\`
+
+## 4. Smoke test
+
+\`\`\`js
+await claw.createAction({
+  action_type: 'test',
+  declared_goal: 'Verify DashClaw connection',
+  risk_score: 10,
+});
+\`\`\`
+
+## 5. Optional: Bootstrap existing state
+
+Clone the repo and run the scanner to import integrations, goals, and memory:
+
+\`\`\`bash
+git clone https://github.com/ucsandman/DashClaw.git /tmp/dashclaw
+node /tmp/dashclaw/scripts/bootstrap-agent.mjs \\
+  --dir . --agent-id my-agent \\
+  --api-key "$DASHCLAW_API_KEY" \\
+  --base-url ${baseUrl}
+\`\`\`
+
+## What to report
+
+Use the SDK to report:
+- **Actions** — tool calls, file writes, deployments
+- **Learning / Decisions** — why you chose an approach
+- **Goals** — what you're trying to achieve
+- **Context** — handoff notes, memory, preferences
+
+## Reference
+
+Full SDK docs: ${baseUrl}/docs
+`;
+}

--- a/docs/client-setup-guide.md
+++ b/docs/client-setup-guide.md
@@ -816,7 +816,7 @@ View and configure integration credentials. Supports per-agent overrides. Shows 
 
 ### API Keys (`/api-keys`)
 
-Manage API keys for your workspace. Admins can generate and revoke keys.
+Manage API keys for your workspace. Admins can generate and revoke keys. The **Copy Agent Prompt** button generates a markdown prompt you can paste into any AI agent session (Claude Code, Cursor, etc.) to self-configure a connection to your dashboard — the API key is never included in the prompt.
 
 ### Team (`/team`)
 
@@ -1082,7 +1082,11 @@ The scanner detects:
 5. **Context Points** - extracted sections/summaries from curated markdown docs
 6. **Snippets** - fenced code blocks from a curated set of markdown files
 
-### Option C: Self-Discovery Prompt
+### Option C: Copy Agent Prompt (One-Click)
+
+On the **API Keys** page or the onboarding checklist, click **Copy Agent Prompt**. This copies a markdown prompt to your clipboard that you can paste into any AI agent session (Claude Code, Cursor, etc.). The prompt includes your dashboard URL, SDK install instructions, and a smoke test — but never your API key. The agent will ask you to set `DASHCLAW_API_KEY` in your environment.
+
+### Option D: Self-Discovery Prompt
 
 Paste the contents of `scripts/bootstrap-prompt.md` directly to your agent. The agent introspects its own workspace and pushes state via the SDK. Useful for agents that can execute code.
 

--- a/docs/prompts/dashclaw-agent-connect.md
+++ b/docs/prompts/dashclaw-agent-connect.md
@@ -1,5 +1,7 @@
 # DashClaw: One-Clipboard Setup (Connect An Agent Machine)
 
+> **Tip:** The fastest way to generate this prompt with your dashboard URL pre-filled is the **Copy Agent Prompt** button on the API Keys page (`/api-keys`) or the onboarding checklist.
+
 You are helping a non-technical user connect an agent to their self-hosted DashClaw dashboard.
 
 Rules:


### PR DESCRIPTION
## Summary

- Add a **Copy Agent Prompt** button that generates a markdown prompt users can paste into any AI agent session (Claude Code, Cursor, etc.) to self-configure a DashClaw connection
- API key is never included in the prompt — the agent asks the user to set `DASHCLAW_API_KEY` in their environment
- Button appears on the API Keys page (header + new-key banner) and in the onboarding checklist step 3

## Files changed

- **Created** `app/lib/connectPrompt.js` — pure function generating the markdown prompt
- **Created** `app/components/ConnectAgentButton.js` — client component with clipboard copy + feedback
- **Modified** `app/api-keys/page.js` — added button in 2 placements
- **Modified** `app/components/OnboardingChecklist.js` — added button in SDK install step
- **Modified** `PROJECT_DETAILS.md`, `docs/client-setup-guide.md`, `docs/prompts/dashclaw-agent-connect.md` — documentation

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] `npm run route-sql:check` passes
- [ ] `/api-keys` → create key → "Copy Agent Prompt" appears → copies markdown
- [ ] Pasted markdown has correct base URL, no API key, has SDK instructions
- [ ] Onboarding checklist step 3 shows "Copy Full Setup Prompt" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)