### PR TITLE
fix: landing page redirecting to /login

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1195,6 +1195,11 @@ export async function middleware(request) {
       return NextResponse.next();
     }
 
+    // Landing page is always public
+    if (pathname === '/') {
+      return NextResponse.next();
+    }
+
     // All other matched page routes — require session
     if (!token) {
       return NextResponse.redirect(new URL('/login', request.url));


### PR DESCRIPTION
## Summary

- **Bug**: `dashclaw.io` redirects to `/login` and spins forever instead of showing the landing page
- **Cause**: Middleware session check catches `/` and redirects unauthenticated visitors to `/login`
- **Fix**: Add explicit public pass-through for `/` before the session check

## Test plan

- [ ] Visit `dashclaw.io` — landing page renders without redirect
- [ ] Visit `dashclaw.io/dashboard` — still requires login
- [ ] Visit `dashclaw.io/demo` — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)