### PR TITLE
fix: remove self_host redirect that overrides public landing page

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -861,11 +861,6 @@ export async function middleware(request) {
   const mode = getDashclawMode();
   const demoCookie = isDemoCookieSet(request);
 
-  // self_host mode: redirect root "/" to dashboard (requires login)
-  if (pathname === '/' && mode === 'self_host') {
-    return NextResponse.redirect(new URL('/dashboard', request.url));
-  }
-
   // /demo is always a public entrypoint: it sets a non-secret cookie and forwards into the dashboard.
   // This makes the live demo work even if the deployment forgot to set DASHCLAW_MODE=demo.
   if (pathname === '/demo') {


### PR DESCRIPTION
## Summary
- Removes the early `self_host` mode redirect (`/` → `/dashboard`) in middleware that fired before the "landing page is always public" check
- This caused an infinite redirect loop: `/` → `/dashboard` → `/login` → spin forever
- The landing page check at line 1199 already handles `/` correctly — the early redirect was bypassing it

## Test plan
- [ ] Visit https://www.dashclaw.io/ — should render the landing page, not redirect to /login
- [ ] Visit /dashboard without auth — should still redirect to /login
- [ ] Visit /demo — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)