### PR TITLE
fix: resolve crypto TDZ error in local auth route

### DIFF
--- a/app/api/auth/local/route.js
+++ b/app/api/auth/local/route.js
@@ -25,20 +25,8 @@ export async function POST(request) {
       return NextResponse.json({ error: 'Incorrect password.' }, { status: 401 });
     }
 
-    if (!crypto.subtle.timingSafeEqual) {
-      // Fallback if timingSafeEqual is not available in the environment (unlikely in Next.js 15 Edge/Node)
-      // but the instruction specifically mentioned timingSafeEqual.
-      // In Web Crypto API it is crypto.subtle.timingSafeEqual but it's for ArrayBuffers.
-      // Actually, crypto.timingSafeEqual is available in Node.js.
-      // Next.js Edge Runtime might have different availability.
-      // However, instruction says "using crypto.timingSafeEqual".
-      // Let's use it as if it's available (it is in Node.js crypto module).
-    }
-
-    // Since we are in a Route Handler, it's likely Node.js runtime unless specified.
-    // Next.js 15 uses Node.js by default for Route Handlers.
-    const crypto = await import('node:crypto');
-    if (!crypto.timingSafeEqual(submittedBuf, actualBuf)) {
+    const nodeCrypto = await import('node:crypto');
+    if (!nodeCrypto.timingSafeEqual(submittedBuf, actualBuf)) {
       await new Promise(r => setTimeout(r, 500));
       return NextResponse.json({ error: 'Incorrect password.' }, { status: 401 });
     }


### PR DESCRIPTION
## Summary
- `const crypto = await import('node:crypto')` on line 40 shadowed the global `crypto`, causing a `ReferenceError` (temporal dead zone) on line 28 that broke local password login with a 500 error
- Renamed the import to `nodeCrypto` and removed the dead-code guard block that referenced the shadowed global

## Test plan
- [ ] Set `DASHCLAW_LOCAL_ADMIN_PASSWORD` and attempt local login — should succeed without 500 error