### PR TITLE
fix: self-host middleware graceful fallback for local Postgres

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -232,7 +232,15 @@ async function verifyOrgExists(orgId) {
     return exists;
   } catch (err) {
     console.error('[MIDDLEWARE] Failed to verify org existence:', err.message);
-    // SECURITY: Fail closed — a deleted/revoked org's key must not work during outages
+    // Self-host with local Postgres: Neon HTTP driver can't reach TCP-only Postgres.
+    // Fail open for the default org since migrations already seeded it.
+    const mode = getDashclawMode();
+    if (mode === 'self_host' && orgId === 'org_default') {
+      console.warn('[MIDDLEWARE] Self-host mode: assuming org_default exists (local Postgres, Neon HTTP driver unavailable).');
+      orgExistsCache.set(orgId, { timestamp: now, exists: true });
+      return true;
+    }
+    // SECURITY: Fail closed for non-default orgs or non-self-host deployments.
     return false;
   }
 }
@@ -300,6 +308,9 @@ async function resolveApiKey(keyHash) {
     return result;
   } catch (err) {
     console.error('[AUTH] API key lookup failed:', err.message);
+    // Self-host with local Postgres: Neon HTTP driver can't reach TCP-only Postgres.
+    // The fast-path (DASHCLAW_API_KEY exact match) handles the primary key.
+    // For secondary keys, fail open is not safe — return null.
     return null;
   }
 }


### PR DESCRIPTION
## Problem

When deploying DashClaw in `self_host` mode with a local (TCP-only) Postgres database, the Guard API and all authenticated endpoints return:

```json
{"error": "Database not initialized.", "code": "SCHEMA_NOT_INITIALIZED"}
```

...even though all 77 tables are present and migrations have been applied.

## Root Cause

The Next.js Edge Runtime middleware (`middleware.js`) imports `neon()` from `@neondatabase/serverless` for two database operations:

1. **`verifyOrgExists()`** — checks if the org behind an API key exists
2. **`resolveApiKey()`** — looks up secondary API keys by hash

The Neon serverless driver uses HTTP/WebSocket transport. Local Postgres only speaks TCP. The Edge Runtime cannot use TCP-based drivers like `postgres` or `pg`, so these calls fail with `TypeError: fetch failed`.

The server-side code in `app/lib/db.js` already handles this correctly with a dual-driver setup (`DASHCLAW_DB_DRIVER=postgres` or Neon URL heuristic), but the middleware doesn't use that module.

## Fix

**`verifyOrgExists()`**: In `self_host` mode, when the Neon driver fails and the org is `org_default`, fail open. This is safe because:
- `org_default` is seeded by the migration script (`auto-migrate.mjs`)
- Non-default orgs and non-self-host deployments still fail closed

**`resolveApiKey()`**: Added clarifying comments. The fast-path (`DASHCLAW_API_KEY` env var exact match via `timingSafeEqual`) handles the primary key before `resolveApiKey()` is called, so the Neon failure only affects secondary key lookups — which correctly return `null`.

## Longer-term suggestion

Consider moving the org verification to a server-side API route (or internal fetch to `/api/setup/status`) instead of doing direct DB queries in Edge middleware. This would let the existing dual-driver logic in `db.js` handle the connection.

## Testing

- Docker Compose with `postgres:16-alpine`
- `DASHCLAW_MODE=self_host`, `DASHCLAW_DB_DRIVER=postgres`
- Verified: `/api/health` → healthy, `/api/guard` → decision: allow, `/api/setup/status` → configured
