### PR TITLE
fix: approvals UI calls stale endpoint after governance refactor

### DIFF
--- a/app/approvals/page.js
+++ b/app/approvals/page.js
@@ -42,10 +42,10 @@ export default function ApprovalsPage() {
   const handleDecision = async (actionId, decision) => {
     try {
       setProcessingId(actionId);
-      const res = await fetch(`/api/actions/${actionId}/approve`, {
+      const res = await fetch(`/api/approvals/${actionId}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ decision })
+        body: JSON.stringify({ decision: decision === 'approve' ? 'allow' : 'deny' })
       });
 
       if (!res.ok) throw new Error('Failed to submit decision');


### PR DESCRIPTION
## Problem

The approvals page (`/approvals`) calls `/api/actions/[actionId]/approve` which was moved to `/api/approvals/[actionId]` during the governance runtime consolidation (commit `6718490`). This means the approve/deny buttons on the dashboard don't work.

## Fix

One-line change in `app/approvals/page.js`:
- Updated fetch URL from `/api/actions/${actionId}/approve` to `/api/approvals/${actionId}`
- Maps UI vocabulary (`approve`/`deny`) to API vocabulary (`allow`/`deny`)

## Testing

- Verified `/api/approvals/[actionId]` route exists and accepts POST with `{ decision: 'allow' | 'deny' }`
- The old route was deleted in the refactor, confirmed via git history