### PR TITLE
feat: Phase 1 agent attribution — add agentId/agentName to guard_decisions schema

### DIFF
--- a/PROJECT_DETAILS.md
+++ b/PROJECT_DETAILS.md
@@ -165,7 +165,7 @@ verified against `sdk/dashclaw.js` on 2026-04-11):
 
 | Domain | Count | Representative methods |
 |:---|:---|:---|
-| Core Governance | 8 | `guard`, `createAction`, `updateOutcome`, `getAction`, `getPendingApprovals`, `approveAction`, `recordAssumption`, `waitForApproval` |
+| Core Governance | 8 | `guard`, `createAction`, `updateOutcome`, `getAction`, `getPendingApprovals`, `approveAction`, `recordAssumption`, `waitForApproval`. Phase 1 agent attribution: pass `agentName` in constructor (auto-included on `guard()`) or `agent_name` per-call. Phase 2 will add JWKS verification. |
 | Decision Integrity | 3 | `registerOpenLoop`, `resolveOpenLoop`, `getSignals` |
 | Operational | 2 | `heartbeat`, `reportConnections` |
 | Learning & Optimization | 4 | `getLearningVelocity`, `getLearningCurves`, `getLessons`, `renderPrompt` |

--- a/__tests__/unit/guard-agent-attribution.test.js
+++ b/__tests__/unit/guard-agent-attribution.test.js
@@ -1,0 +1,137 @@
+/**
+ * Phase 1 agent attribution tests.
+ *
+ * Verifies that the guard route correctly extracts agentId / agentName from:
+ *  1. Explicit body fields (trust-on-assertion baseline)
+ *  2. A JWT Authorization header (decoded, not verified in Phase 1)
+ *  3. Combination: body fields take precedence over JWT claims
+ * Also verifies graceful handling of malformed or absent tokens.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeRequest } from '../helpers.js';
+
+const { mockSql, mockValidateGuardInput, mockEvaluateGuard, mockListGuardDecisions } = vi.hoisted(() => ({
+  mockSql: Object.assign(vi.fn(async () => []), { query: vi.fn(async () => []) }),
+  mockValidateGuardInput: vi.fn(),
+  mockEvaluateGuard: vi.fn(),
+  mockListGuardDecisions: vi.fn(),
+}));
+
+vi.mock('@/lib/db.js', () => ({ getSql: () => mockSql }));
+vi.mock('@/lib/validate', () => ({ validateGuardInput: mockValidateGuardInput }));
+vi.mock('@/lib/guard', () => ({ evaluateGuard: mockEvaluateGuard }));
+vi.mock('@/lib/repositories/guard.repository.js', () => ({ listGuardDecisions: mockListGuardDecisions }));
+
+import { POST } from '@/api/guard/route.js';
+
+// JWT with sub=agt_test123 and agent_name=test-worker (signature is fake — Phase 1 doesn't verify)
+const TEST_JWT = 'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZ3RfdGVzdDEyMyIsImFnZW50X25hbWUiOiJ0ZXN0LXdvcmtlciIsImlzcyI6Imh0dHBzOi8vYWdlbnRsYWlyLmRldiIsImV4cCI6OTk5OTk5OTk5OX0.fakesig';
+
+describe('/api/guard — Phase 1 agent attribution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DATABASE_URL = 'postgres://unit-test';
+    process.env.DASHCLAW_MODE = 'cloud';
+    mockSql.mockImplementation(async () => []);
+    mockSql.query.mockImplementation(async () => []);
+    mockEvaluateGuard.mockResolvedValue({ decision: 'allow', reasons: [], warnings: [], matched_policies: [] });
+  });
+
+  it('passes agent_id and agent_name from request body to evaluateGuard', async () => {
+    mockValidateGuardInput.mockImplementation((body) => ({
+      valid: true,
+      data: body,
+      errors: [],
+    }));
+
+    await POST(makeRequest('http://localhost/api/guard', {
+      headers: { 'x-org-id': 'org_1' },
+      body: { action_type: 'deploy', agent_id: 'agt_body_id', agent_name: 'body-worker' },
+    }));
+
+    expect(mockEvaluateGuard).toHaveBeenCalledWith(
+      'org_1',
+      expect.objectContaining({ agent_id: 'agt_body_id', agent_name: 'body-worker' }),
+      mockSql,
+      expect.any(Object)
+    );
+  });
+
+  it('extracts agent_id and agent_name from JWT Authorization header', async () => {
+    mockValidateGuardInput.mockImplementation((body) => ({
+      valid: true,
+      data: body,
+      errors: [],
+    }));
+
+    await POST(makeRequest('http://localhost/api/guard', {
+      headers: {
+        'x-org-id': 'org_1',
+        'authorization': `Bearer ${TEST_JWT}`,
+      },
+      body: { action_type: 'deploy' },
+    }));
+
+    expect(mockValidateGuardInput).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_id: 'agt_test123', agent_name: 'test-worker' })
+    );
+  });
+
+  it('body agent_id and agent_name take precedence over JWT claims', async () => {
+    mockValidateGuardInput.mockImplementation((body) => ({
+      valid: true,
+      data: body,
+      errors: [],
+    }));
+
+    await POST(makeRequest('http://localhost/api/guard', {
+      headers: {
+        'x-org-id': 'org_1',
+        'authorization': `Bearer ${TEST_JWT}`,
+      },
+      body: { action_type: 'deploy', agent_id: 'agt_explicit', agent_name: 'explicit-worker' },
+    }));
+
+    expect(mockValidateGuardInput).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_id: 'agt_explicit', agent_name: 'explicit-worker' })
+    );
+  });
+
+  it('ignores malformed JWT and falls through to body values', async () => {
+    mockValidateGuardInput.mockImplementation((body) => ({
+      valid: true,
+      data: body,
+      errors: [],
+    }));
+
+    await POST(makeRequest('http://localhost/api/guard', {
+      headers: {
+        'x-org-id': 'org_1',
+        'authorization': 'Bearer not.a.valid-jwt-at-all',
+      },
+      body: { action_type: 'deploy', agent_id: 'agt_fallback' },
+    }));
+
+    // Should not throw; agent_id from body should still be passed
+    expect(mockValidateGuardInput).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_id: 'agt_fallback' })
+    );
+    expect(mockEvaluateGuard).toHaveBeenCalled();
+  });
+
+  it('proceeds normally when no Authorization header is present', async () => {
+    mockValidateGuardInput.mockImplementation((body) => ({
+      valid: true,
+      data: body,
+      errors: [],
+    }));
+
+    const res = await POST(makeRequest('http://localhost/api/guard', {
+      headers: { 'x-org-id': 'org_1' },
+      body: { action_type: 'read' },
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockEvaluateGuard).toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/guard-agent-attribution.test.js
+++ b/__tests__/unit/guard-agent-attribution.test.js
@@ -1,11 +1,10 @@
 /**
  * Phase 1 agent attribution tests.
  *
- * Verifies that the guard route correctly extracts agentId / agentName from:
- *  1. Explicit body fields (trust-on-assertion baseline)
- *  2. A JWT Authorization header (decoded, not verified in Phase 1)
- *  3. Combination: body fields take precedence over JWT claims
- * Also verifies graceful handling of malformed or absent tokens.
+ * Phase 1 is trust-on-assertion body-only: agent_id and agent_name are
+ * passed directly in the request body and stored verbatim in the audit
+ * trail. No JWT extraction in Phase 1 — that comes in Phase 2 with real
+ * JWKS verification and a verification_status field.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { makeRequest } from '../helpers.js';
@@ -23,12 +22,6 @@ vi.mock('@/lib/guard', () => ({ evaluateGuard: mockEvaluateGuard }));
 vi.mock('@/lib/repositories/guard.repository.js', () => ({ listGuardDecisions: mockListGuardDecisions }));
 
 import { POST } from '@/api/guard/route.js';
-
-// JWT with sub=agt_test123 and agent_name=test-worker (signature is fake — Phase 1 doesn't verify)
-const TEST_JWT = 'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZ3RfdGVzdDEyMyIsImFnZW50X25hbWUiOiJ0ZXN0LXdvcmtlciIsImlzcyI6Imh0dHBzOi8vYWdlbnRsYWlyLmRldiIsImV4cCI6OTk5OTk5OTk5OX0.fakesig';
-
-// AgentLair AAT with sub=acc_test123 and al_name=pico/test-worker (AgentLair-specific claim)
-const AGENTLAIR_AAT_JWT = 'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiAiYWNjX3Rlc3QxMjMiLCAiYWxfbmFtZSI6ICJwaWNvL3Rlc3Qtd29ya2VyIiwgImlzcyI6ICJodHRwczovL2FnZW50bGFpci5kZXYiLCAiZXhwIjogOTk5OTk5OTk5OX0.fakesig';
 
 describe('/api/guard — Phase 1 agent attribution', () => {
   beforeEach(() => {
@@ -60,84 +53,24 @@ describe('/api/guard — Phase 1 agent attribution', () => {
     );
   });
 
-  it('extracts agent_id and agent_name from JWT Authorization header', async () => {
+  it('proceeds normally when Authorization header is present but agent identity comes from body', async () => {
     mockValidateGuardInput.mockImplementation((body) => ({
       valid: true,
       data: body,
       errors: [],
     }));
 
+    // Phase 1: JWT in Authorization header is ignored; body fields are the source of truth
     await POST(makeRequest('http://localhost/api/guard', {
       headers: {
         'x-org-id': 'org_1',
-        'authorization': `Bearer ${TEST_JWT}`,
+        'authorization': 'Bearer some.bearer.token',
       },
-      body: { action_type: 'deploy' },
+      body: { action_type: 'deploy', agent_id: 'agt_from_body', agent_name: 'body-worker' },
     }));
 
     expect(mockValidateGuardInput).toHaveBeenCalledWith(
-      expect.objectContaining({ agent_id: 'agt_test123', agent_name: 'test-worker' })
-    );
-  });
-
-  it('body agent_id and agent_name take precedence over JWT claims', async () => {
-    mockValidateGuardInput.mockImplementation((body) => ({
-      valid: true,
-      data: body,
-      errors: [],
-    }));
-
-    await POST(makeRequest('http://localhost/api/guard', {
-      headers: {
-        'x-org-id': 'org_1',
-        'authorization': `Bearer ${TEST_JWT}`,
-      },
-      body: { action_type: 'deploy', agent_id: 'agt_explicit', agent_name: 'explicit-worker' },
-    }));
-
-    expect(mockValidateGuardInput).toHaveBeenCalledWith(
-      expect.objectContaining({ agent_id: 'agt_explicit', agent_name: 'explicit-worker' })
-    );
-  });
-
-  it('extracts agent_name from AgentLair al_name claim (AAT format)', async () => {
-    mockValidateGuardInput.mockImplementation((body) => ({
-      valid: true,
-      data: body,
-      errors: [],
-    }));
-
-    await POST(makeRequest('http://localhost/api/guard', {
-      headers: {
-        'x-org-id': 'org_1',
-        'authorization': `Bearer ${AGENTLAIR_AAT_JWT}`,
-      },
-      body: { action_type: 'deploy' },
-    }));
-
-    expect(mockValidateGuardInput).toHaveBeenCalledWith(
-      expect.objectContaining({ agent_id: 'acc_test123', agent_name: 'pico/test-worker' })
-    );
-  });
-
-  it('ignores malformed JWT and falls through to body values', async () => {
-    mockValidateGuardInput.mockImplementation((body) => ({
-      valid: true,
-      data: body,
-      errors: [],
-    }));
-
-    await POST(makeRequest('http://localhost/api/guard', {
-      headers: {
-        'x-org-id': 'org_1',
-        'authorization': 'Bearer not.a.valid-jwt-at-all',
-      },
-      body: { action_type: 'deploy', agent_id: 'agt_fallback' },
-    }));
-
-    // Should not throw; agent_id from body should still be passed
-    expect(mockValidateGuardInput).toHaveBeenCalledWith(
-      expect.objectContaining({ agent_id: 'agt_fallback' })
+      expect.objectContaining({ agent_id: 'agt_from_body', agent_name: 'body-worker' })
     );
     expect(mockEvaluateGuard).toHaveBeenCalled();
   });

--- a/__tests__/unit/guard-agent-attribution.test.js
+++ b/__tests__/unit/guard-agent-attribution.test.js
@@ -27,6 +27,9 @@ import { POST } from '@/api/guard/route.js';
 // JWT with sub=agt_test123 and agent_name=test-worker (signature is fake — Phase 1 doesn't verify)
 const TEST_JWT = 'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhZ3RfdGVzdDEyMyIsImFnZW50X25hbWUiOiJ0ZXN0LXdvcmtlciIsImlzcyI6Imh0dHBzOi8vYWdlbnRsYWlyLmRldiIsImV4cCI6OTk5OTk5OTk5OX0.fakesig';
 
+// AgentLair AAT with sub=acc_test123 and al_name=pico/test-worker (AgentLair-specific claim)
+const AGENTLAIR_AAT_JWT = 'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJzdWIiOiAiYWNjX3Rlc3QxMjMiLCAiYWxfbmFtZSI6ICJwaWNvL3Rlc3Qtd29ya2VyIiwgImlzcyI6ICJodHRwczovL2FnZW50bGFpci5kZXYiLCAiZXhwIjogOTk5OTk5OTk5OX0.fakesig';
+
 describe('/api/guard — Phase 1 agent attribution', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -94,6 +97,26 @@ describe('/api/guard — Phase 1 agent attribution', () => {
 
     expect(mockValidateGuardInput).toHaveBeenCalledWith(
       expect.objectContaining({ agent_id: 'agt_explicit', agent_name: 'explicit-worker' })
+    );
+  });
+
+  it('extracts agent_name from AgentLair al_name claim (AAT format)', async () => {
+    mockValidateGuardInput.mockImplementation((body) => ({
+      valid: true,
+      data: body,
+      errors: [],
+    }));
+
+    await POST(makeRequest('http://localhost/api/guard', {
+      headers: {
+        'x-org-id': 'org_1',
+        'authorization': `Bearer ${AGENTLAIR_AAT_JWT}`,
+      },
+      body: { action_type: 'deploy' },
+    }));
+
+    expect(mockValidateGuardInput).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_id: 'acc_test123', agent_name: 'pico/test-worker' })
     );
   });
 

--- a/app/api/guard/route.js
+++ b/app/api/guard/route.js
@@ -32,7 +32,9 @@ function extractAgentClaimsFromJwt(authHeader) {
     );
     const result = {};
     if (typeof payload.sub === 'string' && payload.sub) result.agent_id = payload.sub;
-    if (typeof payload.agent_name === 'string' && payload.agent_name) result.agent_name = payload.agent_name;
+    // AgentLair AATs use 'al_name'; generic JWTs may use 'agent_name' — support both
+    const agentName = payload.al_name || payload.agent_name;
+    if (typeof agentName === 'string' && agentName) result.agent_name = agentName;
     return result;
   } catch {
     // Malformed JWT — ignore silently, fall through to body-provided values
@@ -48,7 +50,7 @@ function extractAgentClaimsFromJwt(authHeader) {
  * Query: ?include_signals=true (optional, adds live signal warnings)
  *
  * Agent identity resolution (Phase 1, trust-on-assertion):
- *   1. JWT claims from Authorization: Bearer <token> (agent_id ← sub, agent_name ← agent_name)
+ *   1. JWT claims from Authorization: Bearer <token> (agent_id ← sub, agent_name ← al_name || agent_name)
  *   2. Explicit body fields agent_id / agent_name (override JWT claims if provided)
  * No signature verification in Phase 1 — the existing API-key boundary provides authentication.
  */

--- a/app/api/guard/route.js
+++ b/app/api/guard/route.js
@@ -12,63 +12,23 @@ import { listGuardDecisions } from '../../lib/repositories/guard.repository.js';
 import { isSelfHostModeEnabled } from '../../lib/selfHost.js';
 
 /**
- * Decode a JWT payload without verifying the signature.
- * Phase 1: trust-on-assertion — the caller is already authenticated via API key.
- * We extract agent_id (sub) and agent_name purely for attribution in the audit trail.
- * Phase 2 will add JWKS verification on top.
- *
- * @param {string} authHeader - raw Authorization header value
- * @returns {{ agent_id?: string, agent_name?: string }} extracted claims (empty if not a valid JWT)
- */
-function extractAgentClaimsFromJwt(authHeader) {
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return {};
-  try {
-    const token = authHeader.slice(7);
-    const parts = token.split('.');
-    if (parts.length !== 3) return {};
-    // Base64url decode the payload (no verification in Phase 1)
-    const payload = JSON.parse(
-      Buffer.from(parts[1], 'base64url').toString('utf8')
-    );
-    const result = {};
-    if (typeof payload.sub === 'string' && payload.sub) result.agent_id = payload.sub;
-    // AgentLair AATs use 'al_name'; generic JWTs may use 'agent_name' — support both
-    const agentName = payload.al_name || payload.agent_name;
-    if (typeof agentName === 'string' && agentName) result.agent_name = agentName;
-    return result;
-  } catch {
-    // Malformed JWT — ignore silently, fall through to body-provided values
-    return {};
-  }
-}
-
-/**
  * POST /api/guard — Evaluate guard policies for a proposed action.
  * Returns allow/warn/block/require_approval.
  *
  * Body: { action_type, risk_score?, agent_id?, agent_name?, systems_touched?, reversible?, declared_goal? }
  * Query: ?include_signals=true (optional, adds live signal warnings)
  *
- * Agent identity resolution (Phase 1, trust-on-assertion):
- *   1. JWT claims from Authorization: Bearer <token> (agent_id ← sub, agent_name ← al_name || agent_name)
- *   2. Explicit body fields agent_id / agent_name (override JWT claims if provided)
- * No signature verification in Phase 1 — the existing API-key boundary provides authentication.
+ * Agent identity (Phase 1, trust-on-assertion):
+ *   Pass agent_id and agent_name directly in the request body. The existing
+ *   API-key boundary provides authentication. Phase 2 will add JWKS verification
+ *   and a verification_status field.
  */
 export async function POST(request) {
   try {
     const orgId = getOrgId(request);
     const body = await request.json();
 
-    // Extract agent identity from JWT if present (Phase 1: no verification)
-    const jwtClaims = extractAgentClaimsFromJwt(request.headers.get('authorization'));
-
-    // Body-provided values take precedence over JWT claims
-    const enrichedBody = {
-      ...jwtClaims,
-      ...body,
-    };
-
-    const { valid, data, errors } = validateGuardInput(enrichedBody);
+    const { valid, data, errors } = validateGuardInput(body);
 
     if (!valid) {
       return NextResponse.json({ error: 'Validation failed', details: errors }, { status: 400 });

--- a/app/api/guard/route.js
+++ b/app/api/guard/route.js
@@ -28,7 +28,7 @@ function extractAgentClaimsFromJwt(authHeader) {
     if (parts.length !== 3) return {};
     // Base64url decode the payload (no verification in Phase 1)
     const payload = JSON.parse(
-      Buffer.from(parts[1].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8')
+      Buffer.from(parts[1], 'base64url').toString('utf8')
     );
     const result = {};
     if (typeof payload.sub === 'string' && payload.sub) result.agent_id = payload.sub;

--- a/app/api/guard/route.js
+++ b/app/api/guard/route.js
@@ -12,17 +12,61 @@ import { listGuardDecisions } from '../../lib/repositories/guard.repository.js';
 import { isSelfHostModeEnabled } from '../../lib/selfHost.js';
 
 /**
+ * Decode a JWT payload without verifying the signature.
+ * Phase 1: trust-on-assertion — the caller is already authenticated via API key.
+ * We extract agent_id (sub) and agent_name purely for attribution in the audit trail.
+ * Phase 2 will add JWKS verification on top.
+ *
+ * @param {string} authHeader - raw Authorization header value
+ * @returns {{ agent_id?: string, agent_name?: string }} extracted claims (empty if not a valid JWT)
+ */
+function extractAgentClaimsFromJwt(authHeader) {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return {};
+  try {
+    const token = authHeader.slice(7);
+    const parts = token.split('.');
+    if (parts.length !== 3) return {};
+    // Base64url decode the payload (no verification in Phase 1)
+    const payload = JSON.parse(
+      Buffer.from(parts[1].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8')
+    );
+    const result = {};
+    if (typeof payload.sub === 'string' && payload.sub) result.agent_id = payload.sub;
+    if (typeof payload.agent_name === 'string' && payload.agent_name) result.agent_name = payload.agent_name;
+    return result;
+  } catch {
+    // Malformed JWT — ignore silently, fall through to body-provided values
+    return {};
+  }
+}
+
+/**
  * POST /api/guard — Evaluate guard policies for a proposed action.
  * Returns allow/warn/block/require_approval.
  *
- * Body: { action_type, risk_score?, agent_id?, systems_touched?, reversible?, declared_goal? }
+ * Body: { action_type, risk_score?, agent_id?, agent_name?, systems_touched?, reversible?, declared_goal? }
  * Query: ?include_signals=true (optional, adds live signal warnings)
+ *
+ * Agent identity resolution (Phase 1, trust-on-assertion):
+ *   1. JWT claims from Authorization: Bearer <token> (agent_id ← sub, agent_name ← agent_name)
+ *   2. Explicit body fields agent_id / agent_name (override JWT claims if provided)
+ * No signature verification in Phase 1 — the existing API-key boundary provides authentication.
  */
 export async function POST(request) {
   try {
     const orgId = getOrgId(request);
     const body = await request.json();
-    const { valid, data, errors } = validateGuardInput(body);
+
+    // Extract agent identity from JWT if present (Phase 1: no verification)
+    const jwtClaims = extractAgentClaimsFromJwt(request.headers.get('authorization'));
+
+    // Body-provided values take precedence over JWT claims
+    const enrichedBody = {
+      ...jwtClaims,
+      ...body,
+    };
+
+    const { valid, data, errors } = validateGuardInput(enrichedBody);
 
     if (!valid) {
       return NextResponse.json({ error: 'Validation failed', details: errors }, { status: 400 });

--- a/app/docs/page.js
+++ b/app/docs/page.js
@@ -501,15 +501,16 @@ npm run doctor`}</CodeBlock>
           {/* ── Constructor ── */}
           <section id="constructor" className="scroll-mt-20 py-12 border-b border-border">
             <h2 className="text-2xl font-bold tracking-tight mb-2">Constructor</h2>
-            <DocsCodeTabs 
-              nodeSnippet="const claw = new DashClaw({ baseUrl, apiKey, agentId });"
-              pythonSnippet='claw = DashClaw(base_url="...", api_key="...", agent_id="...")'
+            <DocsCodeTabs
+              nodeSnippet={`const claw = new DashClaw({ baseUrl, apiKey, agentId, agentName });`}
+              pythonSnippet='claw = DashClaw(base_url="...", api_key="...", agent_id="...", agent_name="...")'
             />
             <div className="mt-6">
               <ParamTable params={[
                 { name: 'baseUrl / base_url', type: 'string', required: true, desc: 'Dashboard URL' },
                 { name: 'apiKey / api_key', type: 'string', required: true, desc: 'API Key' },
                 { name: 'agentId / agent_id', type: 'string', required: true, desc: 'Unique Agent ID' },
+                { name: 'agentName / agent_name', type: 'string', required: false, desc: 'Human-readable agent label stored in audit trail for attribution. Automatically included on guard() calls if not overridden.' },
               ]} />
             </div>
           </section>

--- a/app/lib/guard.js
+++ b/app/lib/guard.js
@@ -226,11 +226,12 @@ export async function evaluateGuard(orgId, context, sql, options = {}) {
   }
 
   sql`
-    INSERT INTO guard_decisions (id, org_id, agent_id, decision, reason, matched_policies, context, risk_score, action_type, created_at)
+    INSERT INTO guard_decisions (id, org_id, agent_id, agent_name, decision, reason, matched_policies, context, risk_score, action_type, created_at)
     VALUES (
       ${decisionId},
       ${orgId},
       ${context.agent_id || null},
+      ${context.agent_name || null},
       ${highestDecision},
       ${reasons.join('; ') || null},
       ${JSON.stringify(matchedPolicies)},
@@ -249,6 +250,7 @@ export async function evaluateGuard(orgId, context, sql, options = {}) {
       id: decisionId,
       org_id: orgId,
       agent_id: context.agent_id || null,
+      agent_name: context.agent_name || null,
       decision: highestDecision,
       reason: reasons.join('; ') || null,
       matched_policies: matchedPolicies,

--- a/app/lib/repositories/guard.repository.js
+++ b/app/lib/repositories/guard.repository.js
@@ -49,7 +49,7 @@ export async function listGuardDecisions(sql, orgId, { agentId, decision, limit 
 
     const where = conditions.join(' AND ');
     const query = `
-      SELECT id, org_id, agent_id, action_type, risk_score, decision, ${reasonCol}, created_at
+      SELECT id, org_id, agent_id, agent_name, action_type, risk_score, decision, ${reasonCol}, created_at
       FROM guard_decisions
       WHERE ${where}
       ORDER BY created_at DESC

--- a/app/lib/validate.js
+++ b/app/lib/validate.js
@@ -207,6 +207,7 @@ const GUARD_INPUT_SCHEMA = {
   action:          { type: 'string', alias: 'action_type' }, // Alias for action_type
   risk_score:      { type: 'integer', min: 0, max: 100 },
   agent_id:        { type: 'string', maxLength: 128 },
+  agent_name:      { type: 'string', maxLength: 256 },
   systems_touched: { type: 'array', maxItems: 50 },
   reversible:      { type: 'boolean' },
   declared_goal:   { type: 'string', maxLength: 2000 },

--- a/docs/sdk-parity.md
+++ b/docs/sdk-parity.md
@@ -98,7 +98,7 @@ That is acceptable temporarily, but it should not define future product directio
 
 | Domain | Canonical Node | Legacy Node | Python | Status |
 |---|---|---|---|---|
-| Guard / actions / approvals | Yes | Yes | Yes | Stable, canonical in main SDK. Approvals use `POST /api/approvals/[actionId]` (shared by browser, CLI, `/approve` mobile PWA, SDK polling) |
+| Guard / actions / approvals | Yes | Yes | Yes | Stable, canonical in main SDK. Approvals use `POST /api/approvals/[actionId]` (shared by browser, CLI, `/approve` mobile PWA, SDK polling). Phase 1 agent attribution (`agent_id`, `agent_name`) supported in both SDKs — pass in constructor or per-call body. Phase 2 will add JWKS verification. |
 | Sessions / action graph | Yes | Partial overlap | Yes | Stable, canonical in main SDK |
 | Loops and assumptions | Yes | Yes | Yes | Canonical in main SDK |
 | Workflows | Yes | Historical overlap | Yes | Canonical in main SDK, with Python route-contract parity for template CRUD, launch, and execute. `POST /api/workflows/draft` NL-to-workflow endpoint also exposed |

--- a/drizzle/0003_guard_decisions_agent_name.sql
+++ b/drizzle/0003_guard_decisions_agent_name.sql
@@ -1,0 +1,6 @@
+-- Phase 1: agent attribution — add agent_name to guard_decisions
+-- Enables trust-on-assertion attribution: callers can pass agent_name
+-- alongside agent_id, and it is stored verbatim on every audit entry.
+-- No verification in Phase 1; cross-org JWKS verification comes in Phase 2.
+
+ALTER TABLE "guard_decisions" ADD COLUMN "agent_name" text;

--- a/schema/schema.js
+++ b/schema/schema.js
@@ -479,6 +479,7 @@ export const guardDecisions = pgTable('guard_decisions', {
   id: text('id').primaryKey(),
   orgId: text('org_id').notNull().references(() => organizations.id),
   agentId: text('agent_id'),
+  agentName: text('agent_name'),
   decision: text('decision').notNull(),
   reason: text('reason'),
   matchedPolicies: text('matched_policies'),

--- a/sdk-python/README.md
+++ b/sdk-python/README.md
@@ -26,15 +26,16 @@ The Python SDK is the full platform SDK (235 methods). The constructor accepts b
 
 ### v2-compatible constructor (recommended for new agents)
 
-These 3 parameters are the only ones available in the Node.js v2 SDK (`new DashClaw({ baseUrl, apiKey, agentId })`):
+These parameters are available in both the Node.js v2 SDK and the Python SDK:
 
 ```python
 from dashclaw import DashClaw
 
 claw = DashClaw(
-    base_url="http://localhost:3000",  # Required (v2)
-    api_key="your-api-key",            # Required (v2)
-    agent_id="my-python-agent",        # Required (v2)
+    base_url="http://localhost:3000",      # Required (v2)
+    api_key="your-api-key",                # Required (v2)
+    agent_id="my-python-agent",            # Required (v2)
+    agent_name="My Python Agent",          # Optional (v2) — stored in audit trail for attribution
 )
 ```
 
@@ -47,7 +48,7 @@ claw = DashClaw(
     base_url="http://localhost:3000",  # Required (v2)
     api_key="your-api-key",            # Required (v2)
     agent_id="my-python-agent",        # Required (v2)
-    agent_name="My Python Agent",      # v1 only
+    agent_name="My Python Agent",      # Optional (v2) — stored in audit trail
     auto_recommend="warn",             # v1 only: off | warn | enforce
     hitl_mode="wait",                  # v1 only: automatically wait for human approval
 )

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -32,7 +32,8 @@ import { DashClaw, GuardBlockedError, ApprovalDeniedError } from 'dashclaw';
 const claw = new DashClaw({
   baseUrl: process.env.DASHCLAW_BASE_URL,
   apiKey: process.env.DASHCLAW_API_KEY,
-  agentId: 'my-agent'
+  agentId: 'my-agent',
+  agentName: 'My Agent',  // optional — stored in audit trail for attribution
 });
 
 // 1. Ask permission
@@ -82,6 +83,7 @@ claw = DashClaw(
     base_url=os.environ["DASHCLAW_BASE_URL"],
     api_key=os.environ["DASHCLAW_API_KEY"],
     agent_id="my-agent",
+    agent_name="My Agent",  # optional — stored in audit trail for attribution
 )
 
 # 1. Ask permission
@@ -242,7 +244,7 @@ See:
 The v2 SDK exposes the stable governance runtime plus promoted execution domains in the canonical Node client:
 
 ### Core Runtime
-- `guard(context)` -- Policy evaluation ("Can I do X?"). Returns `risk_score` (server-computed) and `agent_risk_score` (raw agent value)
+- `guard(context)` -- Policy evaluation ("Can I do X?"). Returns `risk_score` (server-computed) and `agent_risk_score` (raw agent value). Automatically includes `agent_name` from the constructor if not overridden in the call context.
 - `createAction(action)` -- Lifecycle tracking ("I am doing X")
 - `updateOutcome(id, outcome)` -- Result recording ("X finished with Y")
 - `recordAssumption(assumption)` -- Integrity tracking ("I believe Z while doing X")

--- a/sdk/dashclaw.js
+++ b/sdk/dashclaw.js
@@ -25,8 +25,9 @@ class DashClaw {
    * @param {string} options.baseUrl - DashClaw base URL
    * @param {string} options.apiKey - API key for authentication
    * @param {string} options.agentId - Unique identifier for this agent
+   * @param {string} [options.agentName] - Human-readable label for this agent (stored in audit trail)
    */
-  constructor({ baseUrl, apiKey, agentId }) {
+  constructor({ baseUrl, apiKey, agentId, agentName }) {
     if (!baseUrl) throw new Error('baseUrl is required');
     if (!apiKey) throw new Error('apiKey is required');
     if (!agentId) throw new Error('agentId is required');
@@ -34,6 +35,7 @@ class DashClaw {
     this.baseUrl = baseUrl.replace(/\/$/, '');
     this.apiKey = apiKey;
     this.agentId = agentId;
+    this.agentName = agentName || null;
 
     this.execution = {
       capabilities: {
@@ -96,6 +98,8 @@ class DashClaw {
     return this._request('/api/guard', 'POST', {
       ...context,
       agent_id: context.agent_id || this.agentId,
+      // Include agent_name for audit attribution if not already provided by caller
+      ...(context.agent_name == null && this.agentName ? { agent_name: this.agentName } : {}),
     });
   }
 


### PR DESCRIPTION
Closes #79 (Phase 1).

## What this does

Adds optional `agent_id` / `agent_name` attribution to every guard decision audit entry. Phase 1 is **trust-on-assertion** — no cryptographic verification. Callers pass `agent_id` and `agent_name` directly in the request body; the API-key boundary provides authentication.

Phase 2 (JWKS verification, `verification_status`) will follow in a separate PR once this lands and bakes.

## Changes

| File | Change |
|---|---|
| `schema/schema.js` | Add `agentName` column to `guardDecisions` table (`agent_id` already existed) |
| `drizzle/0003_guard_decisions_agent_name.sql` | Migration: `ALTER TABLE guard_decisions ADD COLUMN agent_name text` |
| `app/lib/validate.js` | Add `agent_name` to `GUARD_INPUT_SCHEMA` (optional, max 256 chars) |
| `app/api/guard/route.js` | Update JSDoc to document body-only identity fields; no JWT extraction |
| `app/lib/guard.js` | Persist `agent_name` in the audit INSERT and event payload |
| `app/lib/repositories/guard.repository.js` | Add `agent_name` to SELECT clause so it is returned in audit listings |
| `sdk/dashclaw.js` | Accept optional `agentName` in constructor; pass it on `guard()` calls |
| `sdk/README.md` | Document `agentName` constructor param and `agent_name` on `guard()` |
| `sdk-python/README.md` | Move `agent_name` to v2-compatible section |
| `app/docs/page.js` | Add `agentName / agent_name` row to Constructor ParamTable |
| `docs/sdk-parity.md` | Update Domain Status Matrix — Guard row |
| `PROJECT_DETAILS.md` | Update Core Governance row |
| `__tests__/unit/guard-agent-attribution.test.js` | 3 unit tests for body attribution, ignored Authorization header, and no-auth path |

## Schema delta

`agent_id` is an existing column on `guard_decisions`. This PR adds `agent_name` only.

The migration file name (`0003_guard_decisions_agent_name.sql`) and the single `ALTER TABLE` line both reflect this. Guard decisions already stored `agent_id` from request body; Phase 1 adds the matching name field alongside it.

## Agent identity (Phase 1 — body-only)

`agent_id` and `agent_name` are passed directly in the request body. The `Authorization` header is accepted but ignored — no JWT extraction in Phase 1.

```typescript
// SDK usage
const dashclaw = new DashClaw({
  baseUrl: 'https://dashclaw.example.com',
  apiKey: 'dc_key_...',
  agentId: 'agt_7f3a2b',
  agentName: 'deploy-checker',  // new optional field
});

// Or pass per-call
await dashclaw.guard({
  action_type: 'deploy',
  agent_id: 'agt_7f3a2b',
  agent_name: 'deploy-checker',
});
```

## Test results

```
✓ passes agent_id and agent_name from request body to evaluateGuard
✓ proceeds normally when Authorization header is present but agent identity comes from body
✓ proceeds normally when no Authorization header is present
```

All existing guard route tests still pass.

## What this doesn't touch

- Existing API key auth is unchanged
- No `verification_status` field yet (Phase 2)
- No JWKS lookup (Phase 2)
- Config is additive — unset `agent_name` just stores `null`

---

cc @ucsandman — Phase 1 as discussed in #79.