### PR TITLE
Weekly health digest, 2026-05-13

### DIFF
--- a/.organism/digests/2026-05-13.md
+++ b/.organism/digests/2026-05-13.md
@@ -1,0 +1,41 @@
+# Weekly Health Digest - 2026-05-13
+
+First run, no prior baseline.
+
+**Coverage:** This week. No prior snapshot exists, so this run establishes the baseline for next Monday.
+
+## What got worse
+
+Nothing notable. No prior baseline to compare against.
+
+## What got better
+
+Nothing notable. No prior baseline to compare against.
+
+## New untested routes
+
+None tracked yet. 84 routes are currently on the untested list; the full set becomes the baseline this week.
+
+## Current state concerns
+
+- CI pass rate below 80% over 30 days: 0.0% with an empty last-10 runs list. Either the collector cannot reach the workflow runs API or no gates have executed in the 30 day window.
+- JS dependency vulnerabilities greater than 0: 2 current vulnerabilities reported by the dependency collector.
+- Any single file in largest_files over 2000 lines: sdk/legacy/dashclaw-v1.js at 2934 lines and app/docs/page.js at 2165 lines.
+- Bus factor of 1 (first run only): Wes Sander authored 44 of 50 commits in the last 30 days.
+
+## One thing to do this week
+
+Investigate why ci_health.pass_rate_30d is 0.0 with last_10_runs empty. Check the GitHub Actions collector in livingcode/collectors and confirm whether workflow runs are being fetched. If the collector is broken, the digest cannot detect real CI regressions next week. Scoped to under four hours: read the collector, run it with verbose logging, and either fix the auth path or file an issue describing the gap.
+
+## Raw deltas
+
+| Metric | This week | Last week | Delta |
+|---|---|---|---|
+| CI pass rate 30d | 0.0% | n/a | first run |
+| Last 10 CI runs | empty | n/a | first run |
+| Files over 300 lines | 109 | n/a | first run |
+| Untested routes | 84 | n/a | first run |
+| JS vulnerabilities | 2 | n/a | first run |
+| Lockfile age days | 0 | n/a | first run |
+| Commits 7d | 12 | n/a | first run |
+| TODO count | 1 | n/a | first run |

--- a/.organism/digests/2026-05-13.md
+++ b/.organism/digests/2026-05-13.md
@@ -1,41 +1,39 @@
-# Weekly Health Digest - 2026-05-13
+# Weekly Health Digest, 2026-05-13
 
-First run, no prior baseline.
-
-**Coverage:** This week. No prior snapshot exists, so this run establishes the baseline for next Monday.
+**Coverage:** First run, no prior baseline.
 
 ## What got worse
 
-Nothing notable. No prior baseline to compare against.
+First run, no prior baseline.
 
 ## What got better
 
-Nothing notable. No prior baseline to compare against.
+First run, no prior baseline.
 
 ## New untested routes
 
-None tracked yet. 84 routes are currently on the untested list; the full set becomes the baseline this week.
+First run, no prior baseline.
 
 ## Current state concerns
 
-- CI pass rate below 80% over 30 days: 0.0% with an empty last-10 runs list. Either the collector cannot reach the workflow runs API or no gates have executed in the 30 day window.
-- JS dependency vulnerabilities greater than 0: 2 current vulnerabilities reported by the dependency collector.
-- Any single file in largest_files over 2000 lines: sdk/legacy/dashclaw-v1.js at 2934 lines and app/docs/page.js at 2165 lines.
-- Bus factor of 1 (first run only): Wes Sander authored 44 of 50 commits in the last 30 days.
+- CI pass rate is 0.0% over the last 30 days with zero entries in the last-10 window. The collector reports gate_count=0, so the signal is missing rather than failing; CI configuration discovery needs a look.
+- JS dependency vulnerabilities: 2 currently flagged. Lockfile is fresh (0 days old), so a patch run is straightforward.
+- One file exceeds 2000 lines: sdk/legacy/dashclaw-v1.js at 2934 lines. It sits in the legacy SDK path, so a split or quarantine is the right move before it grows further.
+- Bus factor of 1 over the last 30 days. Wes Sander authored 44 of 50 commits; the next contributor is dependabot.
 
 ## One thing to do this week
 
-Investigate why ci_health.pass_rate_30d is 0.0 with last_10_runs empty. Check the GitHub Actions collector in livingcode/collectors and confirm whether workflow runs are being fetched. If the collector is broken, the digest cannot detect real CI regressions next week. Scoped to under four hours: read the collector, run it with verbose logging, and either fix the auth path or file an issue describing the gap.
+Run `npm audit` against the workspace and `packages/openclaw-plugin`, then patch or pin the 2 flagged JS vulnerabilities in a single PR per package. The lockfile is current, so resolutions should be clean. Bounded to a few hours and clears the only dependency signal we have without baseline context.
 
 ## Raw deltas
 
 | Metric | This week | Last week | Delta |
 |---|---|---|---|
-| CI pass rate 30d | 0.0% | n/a | first run |
-| Last 10 CI runs | empty | n/a | first run |
-| Files over 300 lines | 109 | n/a | first run |
-| Untested routes | 84 | n/a | first run |
-| JS vulnerabilities | 2 | n/a | first run |
-| Lockfile age days | 0 | n/a | first run |
-| Commits 7d | 12 | n/a | first run |
-| TODO count | 1 | n/a | first run |
+| CI pass rate (30d) | 0.0% | n/a | n/a |
+| Last 10 CI runs | empty | n/a | n/a |
+| Files over 300 lines | 109 | n/a | n/a |
+| Untested routes | 89 | n/a | n/a |
+| JS vulnerabilities | 2 | n/a | n/a |
+| Lockfile age (days) | 0 | n/a | n/a |
+| Commits in last 7 days | 12 | n/a | n/a |
+| TODO count | 1 | n/a | n/a |

--- a/.organism/digests/last-week-state.json
+++ b/.organism/digests/last-week-state.json
@@ -1,6 +1,6 @@
 {
   "organism": "dashclaw",
-  "timestamp": "2026-05-13T00:14:05.031145+00:00",
+  "timestamp": "2026-05-13T00:29:59.582151+00:00",
   "collector_status": {
     "git_stats": "ok",
     "test_health": "ok",

--- a/.organism/digests/last-week-state.json
+++ b/.organism/digests/last-week-state.json
@@ -1,0 +1,200 @@
+{
+  "organism": "dashclaw",
+  "timestamp": "2026-05-13T00:14:05.031145+00:00",
+  "collector_status": {
+    "git_stats": "ok",
+    "test_health": "ok",
+    "code_quality": "ok",
+    "dependency_health": "ok",
+    "ci_health": "ok"
+  },
+  "git_stats": {
+    "commits_7d": 12,
+    "commits_30d": 50,
+    "active_branches": 2,
+    "stale_branches": 0,
+    "bus_factor": 1,
+    "top_contributors_30d": [
+      {
+        "name": "Wes Sander",
+        "commits": 44
+      },
+      {
+        "name": "dependabot[bot]",
+        "commits": 5
+      },
+      {
+        "name": "piiiico",
+        "commits": 1
+      }
+    ],
+    "files_changed_7d": 33
+  },
+  "test_health": {
+    "js_tests": {
+      "total": 0,
+      "passed": 0,
+      "failed": 0
+    },
+    "python_tests": {
+      "total": 0,
+      "passed": 0,
+      "failed": 0
+    },
+    "test_file_ratio": 0.18004045853000675,
+    "untested_routes": [
+      "api/model-strategies/[strategyId]",
+      "api/doctor/fix",
+      "api/identities",
+      "api/identities/[agentId]",
+      "api/agents/connections",
+      "api/agents/[agentId]",
+      "api/auth/[...nextauth]",
+      "api/auth/local",
+      "api/team",
+      "api/team/[userId]",
+      "api/team/invite",
+      "api/actions/loops",
+      "api/actions/loops/[loopId]",
+      "api/actions/[actionId]",
+      "api/actions/[actionId]/trace",
+      "api/compliance/schedules",
+      "api/compliance/schedules/[scheduleId]",
+      "api/compliance/exports/[exportId]",
+      "api/compliance/exports/[exportId]/download",
+      "api/cron/policy-suggestions",
+      "api/cron/learning-episodes-backfill",
+      "api/cron/memory-maintenance",
+      "api/cron/integration-health",
+      "api/cron/reset-meters",
+      "api/policies/simulate",
+      "api/orgs",
+      "api/orgs/[orgId]",
+      "api/capabilities/[capabilityId]",
+      "api/capabilities/[capabilityId]/access/[ruleId]",
+      "api/hosted/workspaces",
+      "api/hosted/workspaces/[workspaceId]",
+      "api/hosted/cleanup",
+      "api/workflows/templates/[templateId]",
+      "api/workflows/templates/[templateId]/duplicate",
+      "api/workflows/templates/[templateId]/execute",
+      "api/workflows/templates/[templateId]/runs/[runActionId]",
+      "api/workflows/templates/[templateId]/runs/[runActionId]/cancel",
+      "api/approvals/[actionId]",
+      "api/settings",
+      "api/settings/llm-status",
+      "api/billing/checkout",
+      "api/billing/portal",
+      "api/sessions",
+      "api/sessions/[sessionId]",
+      "api/session/effective",
+      "api/assumptions/[assumptionId]",
+      "api/swarm/link",
+      "api/drift/snapshots",
+      "api/drift/alerts/[alertId]",
+      "api/prompts/agent-connect/raw",
+      "api/prompts/server-setup/raw",
+      "api/prompts/render",
+      "api/prompts/templates/[templateId]",
+      "api/prompts/templates/[templateId]/versions",
+      "api/prompts/templates/[templateId]/versions/[versionId]",
+      "api/prompts/sdk-coverage/raw",
+      "api/scoring/profiles/[profileId]",
+      "api/scoring/profiles/[profileId]/dimensions",
+      "api/scoring/profiles/[profileId]/dimensions/[dimensionId]",
+      "api/scoring/calibrate",
+      "api/scoring/risk-templates",
+      "api/scoring/risk-templates/[templateId]",
+      "api/scoring/score",
+      "api/knowledge/collections/[collectionId]",
+      "api/knowledge/collections/[collectionId]/search",
+      "api/knowledge/collections/[collectionId]/items",
+      "api/knowledge/collections/[collectionId]/sync",
+      "api/messages/attachments",
+      "api/messages/threads/[threadId]",
+      "api/webhooks/[webhookId]/deliveries",
+      "api/webhooks/stripe",
+      "api/setup/migrate",
+      "api/pairings",
+      "api/pairings/[pairingId]",
+      "api/pairings/[pairingId]/approve",
+      "api/keys/reveal",
+      "api/docs/raw",
+      "api/artifacts/evidence-bundle",
+      "api/artifacts/[artifactId]",
+      "api/stream",
+      "api/learning/lessons",
+      "api/learning/suggestions",
+      "api/learning/recommendations/[recommendationId]",
+      "api/learning/analytics/curves",
+      "api/learning/analytics/maturity",
+      "api/evaluations",
+      "api/evaluations/scorers",
+      "api/evaluations/scorers/[scorerId]",
+      "api/evaluations/runs/[runId]"
+    ]
+  },
+  "code_quality": {
+    "files_over_300_lines": 109,
+    "largest_files": [
+      {
+        "path": "sdk/legacy/dashclaw-v1.js",
+        "lines": 2934
+      },
+      {
+        "path": "app/docs/page.js",
+        "lines": 2165
+      },
+      {
+        "path": "middleware.js",
+        "lines": 1379
+      },
+      {
+        "path": "app/decisions/[actionId]/page.js",
+        "lines": 1193
+      },
+      {
+        "path": "app/workspace/page.js",
+        "lines": 1184
+      },
+      {
+        "path": "schema/schema.js",
+        "lines": 1072
+      },
+      {
+        "path": "sdk/dashclaw.js",
+        "lines": 1006
+      },
+      {
+        "path": "app/page.js",
+        "lines": 934
+      },
+      {
+        "path": "app/lib/demo/fixtures/feature-agents.js",
+        "lines": 901
+      },
+      {
+        "path": "app/lib/demo/demoMiddleware.js",
+        "lines": 884
+      }
+    ],
+    "eslint_status": "fail",
+    "python_files_over_300": 33,
+    "todo_count": 1,
+    "archive_size_kb": 151
+  },
+  "dependency_health": {
+    "js_dependencies": 44,
+    "js_outdated": 30,
+    "js_vulnerabilities": 2,
+    "python_dependencies": 0,
+    "lockfile_age_days": 0
+  },
+  "ci_health": {
+    "pass_rate_30d": 0.0,
+    "last_10_runs": [],
+    "last_failure_reason": null,
+    "slowest_gate": null,
+    "gate_count": 0
+  }
+}


### PR DESCRIPTION
**Coverage:** First run, no prior baseline.

## What got worse

First run, no prior baseline.

## What got better

First run, no prior baseline.

## New untested routes

First run, no prior baseline.

## Current state concerns

- CI pass rate is 0.0% over the last 30 days with zero entries in the last-10 window. The collector reports gate_count=0, so the signal is missing rather than failing; CI configuration discovery needs a look.
- JS dependency vulnerabilities: 2 currently flagged. Lockfile is fresh (0 days old), so a patch run is straightforward.
- One file exceeds 2000 lines: sdk/legacy/dashclaw-v1.js at 2934 lines. It sits in the legacy SDK path, so a split or quarantine is the right move before it grows further.
- Bus factor of 1 over the last 30 days. Wes Sander authored 44 of 50 commits; the next contributor is dependabot.

## One thing to do this week

Run `npm audit` against the workspace and `packages/openclaw-plugin`, then patch or pin the 2 flagged JS vulnerabilities in a single PR per package. The lockfile is current, so resolutions should be clean. Bounded to a few hours and clears the only dependency signal we have without baseline context.