### PR TITLE
feat(policies): guided front door + consolidated console (v4.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Through 3.x the platform and the SDKs versioned independently, which is why olde
 
 ## [Unreleased]
 
+## [4.4.3] — 2026-06-06
+
+### Changed
+
+- **`/policies` redesign — a front door instead of four equal tabs** — the Policies page no longer opens on a flat `Modes · Shields · Custom · Activity` tab bar with no obvious starting point. With no policies yet it shows one guided screen (not a wizard): Claude Code Mode recommended, its compiled allow / warn / require-approval / block behavior and a real interruption forecast (replayed against your own action history via `previewMode().friction`, honest when there's no history), with agent scope and a spend cap inline and a single Apply. Once policies exist it becomes one consolidated console: a calm summary of which modes and policies govern which agents, plus an apply/change-mode action. Shields, custom authoring (raw YAML import, AI-generate, simulate, test, proof), and the decision Activity feed are demoted intact into a single labeled "Advanced" disclosure — every capability preserved, nothing competing with the primary action. Pure UX/information-architecture reorganization: reuses the existing modes engine, guard, and `/api/policies` (scope/cap applied through the existing `PATCH`); no new routes, SDK methods, MCP tools, guard policies, or schema. SDKs republish at 4.4.3 per the unified-version model.
+
 ## [4.4.2] — 2026-06-06
 
 ### Changed

--- a/__tests__/unit/policies.page.test.jsx
+++ b/__tests__/unit/policies.page.test.jsx
@@ -1,147 +1,73 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
-vi.mock('next-auth/react', () => ({
-  useSession: () => ({ data: { user: { role: 'admin' } } }),
-}));
-
+// PageLayout is chrome; render only its children + title.
 vi.mock('@/components/PageLayout', () => ({
   default: ({ title, children }) => (
-    <div>
-      <h1>{title}</h1>
-      <div>{children}</div>
-    </div>
+    <div><h1>{title}</h1><div>{children}</div></div>
   ),
-}));
-
-vi.mock('@/components/ui/Card', () => ({
-  Card: ({ children }) => <div>{children}</div>,
-  CardContent: ({ children }) => <div>{children}</div>,
-}));
-
-vi.mock('@/components/ui/Badge', () => ({
-  Badge: ({ children }) => <span>{children}</span>,
 }));
 
 vi.mock('@/components/ui/Skeleton', () => ({
   Skeleton: ({ className }) => <div data-testid="skeleton" className={className} />,
 }));
 
-vi.mock('@/components/ui/Stat', () => ({
-  StatCompact: ({ label, value }) => (
-    <div><span>{label}</span><span>{value}</span></div>
-  ),
+// The two state branches are exercised in their own suites; here we only assert
+// the page routes to the correct one based on whether any policy is active.
+vi.mock('@/policies/components/PolicyFrontDoor', () => ({
+  default: () => <div data-testid="front-door">front door</div>,
+}));
+vi.mock('@/policies/components/PolicyConsole', () => ({
+  default: ({ policies }) => <div data-testid="console">console:{policies.length}</div>,
 }));
 
-vi.mock('@/components/ui/EmptyState', () => ({
-  EmptyState: ({ title }) => <div>{title}</div>,
-}));
-
-vi.mock('@/hooks/useRealtime', () => ({
-  useRealtime: () => {},
-}));
-
-vi.mock('@/lib/isDemoMode', () => ({
-  isDemoMode: () => false,
-}));
-
-describe('PoliciesPage', () => {
-  beforeEach(() => {
-    global.fetch = vi.fn(async (url) => {
-      if (String(url) === '/api/policies') {
-        return {
-          ok: true,
-          json: async () => ({
-            policies: [
-              {
-                id: 'pol_1',
-                name: 'Deploy Gate',
-                policy_type: 'require_approval',
-                rules: JSON.stringify({ action_types: ['deploy', 'migrate'], _shield: 'deploy_gate' }),
-                active: 1,
-                agent_ids: null,
-              },
-            ],
-          }),
-        };
-      }
-
-      if (String(url).startsWith('/api/guard/decisions')) {
-        return {
-          ok: true,
-          json: async () => ({
-            decisions: [],
-            total: 0,
-            stats: { blocks: 3, approvals: 1, warns: 2 },
-          }),
-        };
-      }
-
-      if (String(url) === '/api/agents') {
-        return {
-          ok: true,
-          json: async () => ({ agents: [{ agent_id: 'agent_1', agent_name: 'Bot' }] }),
-        };
-      }
-
-      if (String(url) === '/api/policies' && arguments[1]?.method) {
-        return { ok: true, json: async () => ({ policy: { id: 'pol_new' } }) };
-      }
-
-      return { ok: true, json: async () => ({}) };
-    });
+function mockPolicies(policies) {
+  global.fetch = vi.fn(async (url) => {
+    if (String(url) === '/api/policies') {
+      return { ok: true, json: async () => ({ policies }) };
+    }
+    return { ok: true, json: async () => ({}) };
   });
+}
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+describe('PoliciesPage routing', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
 
-  it('renders shield cards on the Shields tab', async () => {
+  it('shows the guided front door when no policy is active', async () => {
+    mockPolicies([]);
     const { default: PoliciesPage } = await import('@/policies/page.jsx');
     render(<PoliciesPage />);
 
-    // Page title
-    expect(screen.getByText('Policies')).toBeTruthy();
-
-    // Tabs exist (Modes is the new first/default tab)
-    expect(screen.getByText('Modes')).toBeTruthy();
-    expect(screen.getByText('Shields')).toBeTruthy();
-    expect(screen.getByText('Custom')).toBeTruthy();
-    expect(screen.getByText('Activity')).toBeTruthy();
-
-    // Switch to Shields, then shield cards render (wait for fetch)
-    fireEvent.click(screen.getByText('Shields'));
-    expect(await screen.findByText('Deploy Gate')).toBeTruthy();
-    expect(screen.getByText('High Risk Review')).toBeTruthy();
-    expect(screen.getByText('Critical Risk Block')).toBeTruthy();
-    expect(screen.getByText('Rate Limiter')).toBeTruthy();
+    expect(await screen.findByTestId('front-door')).toBeTruthy();
+    expect(screen.queryByTestId('console')).toBeNull();
+    // The deleted flat tab bar: the page itself no longer renders co-equal tabs.
+    expect(screen.queryByRole('tab')).toBeNull();
   });
 
-  it('shows stats bar with counts', async () => {
+  it('treats inactive-only policies as the zero state', async () => {
+    mockPolicies([{ id: 'p1', name: 'x', policy_type: 'block', rules: '{}', active: 0, agent_ids: null }]);
     const { default: PoliciesPage } = await import('@/policies/page.jsx');
     render(<PoliciesPage />);
 
-    // Wait for stats to load
-    await waitFor(() => {
-      expect(screen.getByText('active shields').closest('span').textContent).toContain('1');
-    });
+    expect(await screen.findByTestId('front-door')).toBeTruthy();
   });
 
-  it('switches between tabs', async () => {
+  it('shows the governance console when a policy is active', async () => {
+    mockPolicies([
+      { id: 'p1', name: '[Claude Code Mode] Block', policy_type: 'risk_threshold', rules: '{"_mode":"claude-code"}', active: 1, agent_ids: null },
+    ]);
     const { default: PoliciesPage } = await import('@/policies/page.jsx');
     render(<PoliciesPage />);
 
-    // Switch to Shields tab → shield cards
-    fireEvent.click(screen.getByText('Shields'));
-    expect(await screen.findByText('Deploy Gate')).toBeTruthy();
+    expect(await screen.findByTestId('console')).toBeTruthy();
+    expect(screen.queryByTestId('front-door')).toBeNull();
+  });
 
-    // Switch to Activity tab
-    fireEvent.click(screen.getByText('Activity'));
-
-    // Activity tab shows decision filter
-    await waitFor(() => {
-      expect(screen.getByDisplayValue('All decisions')).toBeTruthy();
-    });
+  it('renders the page title', async () => {
+    mockPolicies([]);
+    const { default: PoliciesPage } = await import('@/policies/page.jsx');
+    render(<PoliciesPage />);
+    await waitFor(() => expect(screen.getByText('Policies')).toBeTruthy());
   });
 });

--- a/__tests__/unit/policy-advanced-section.test.jsx
+++ b/__tests__/unit/policy-advanced-section.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// The three relocated surfaces are self-contained; stub them as markers so this
+// suite only verifies the disclosure + switcher wiring, i.e. that every former
+// tab is still reachable after being demoted to Advanced.
+vi.mock('@/policies/components/ShieldsGrid', () => ({ default: () => <div data-testid="shields-grid" /> }));
+vi.mock('@/policies/components/CustomTab', () => ({ default: () => <div data-testid="custom-tab" /> }));
+vi.mock('@/policies/components/ActivityTab', () => ({ default: () => <div data-testid="activity-tab" /> }));
+
+import AdvancedSection from '@/policies/components/AdvancedSection.jsx';
+
+describe('AdvancedSection', () => {
+  it('is collapsed by default and mounts nothing heavy', () => {
+    render(<AdvancedSection />);
+    expect(screen.getByText('Advanced')).toBeTruthy();
+    expect(screen.queryByTestId('shields-grid')).toBeNull();
+    expect(screen.queryByTestId('custom-tab')).toBeNull();
+    expect(screen.queryByTestId('activity-tab')).toBeNull();
+  });
+
+  it('expands to expose Shields, Custom, and Activity (no capability lost)', () => {
+    render(<AdvancedSection />);
+    fireEvent.click(screen.getByText('Advanced'));
+
+    // Shields is the default view inside Advanced.
+    expect(screen.getByTestId('shields-grid')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Custom'));
+    expect(screen.getByTestId('custom-tab')).toBeTruthy();
+    expect(screen.queryByTestId('shields-grid')).toBeNull();
+
+    fireEvent.click(screen.getByText('Activity'));
+    expect(screen.getByTestId('activity-tab')).toBeTruthy();
+    expect(screen.queryByTestId('custom-tab')).toBeNull();
+  });
+});

--- a/__tests__/unit/policy-console.test.jsx
+++ b/__tests__/unit/policy-console.test.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// ModeApply has its own suite; here it is a marker behind the change-mode action.
+vi.mock('@/policies/components/ModeApply', () => ({
+  default: ({ defaultModeId }) => <div data-testid="mode-apply">apply:{defaultModeId}</div>,
+  RECOMMENDED_MODE_ID: 'claude-code',
+}));
+vi.mock('@/policies/components/AdvancedSection', () => ({
+  default: () => <div data-testid="advanced">advanced</div>,
+}));
+
+import PolicyConsole from '@/policies/components/PolicyConsole.jsx';
+
+const POLICIES = [
+  { id: 'p1', name: '[Claude Code Mode] Block', policy_type: 'risk_threshold', rules: '{"_mode":"claude-code"}', active: 1, agent_ids: null },
+  { id: 'p2', name: '[Claude Code Mode] Warn', policy_type: 'risk_threshold', rules: '{"_mode":"claude-code"}', active: 1, agent_ids: null },
+  { id: 'p3', name: 'My custom rule', policy_type: 'block_action_type', rules: '{"action_types":["x"]}', active: 1, agent_ids: null },
+  { id: 'p4', name: 'inactive mode rule', policy_type: 'risk_threshold', rules: '{"_mode":"claude-code"}', active: 0, agent_ids: null },
+];
+
+describe('PolicyConsole', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async (url) => {
+      if (String(url) === '/api/agents') return { ok: true, json: async () => ({ agents: [] }) };
+      if (String(url).startsWith('/api/guard/decisions')) return { ok: true, json: async () => ({ stats: { blocks: 4, approvals: 2 } }) };
+      return { ok: true, json: async () => ({}) };
+    });
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('summarizes which modes and policies govern the agents', () => {
+    render(<PolicyConsole policies={POLICIES} onApplied={vi.fn()} />);
+    expect(screen.getByText('What is governing your agents')).toBeTruthy();
+    // Two active claude-code policies group under the mode name.
+    expect(screen.getByText('Claude Code Mode')).toBeTruthy();
+    expect(screen.getByText('2 rules')).toBeTruthy();
+    // The one non-mode policy groups as Custom; the inactive one is excluded.
+    expect(screen.getByText('Custom policies')).toBeTruthy();
+    expect(screen.getByText('1 rule')).toBeTruthy();
+    // Null agent_ids == all agents.
+    expect(screen.getAllByText('All agents').length).toBeGreaterThan(0);
+  });
+
+  it('offers change-mode and keeps everything else under Advanced', () => {
+    render(<PolicyConsole policies={POLICIES} onApplied={vi.fn()} />);
+    expect(screen.getByText('Apply or change a mode')).toBeTruthy();
+    expect(screen.getByTestId('advanced')).toBeTruthy();
+    // Change-mode surface is disclosed on demand, preselected to the applied mode.
+    expect(screen.queryByTestId('mode-apply')).toBeNull();
+    fireEvent.click(screen.getByText('Apply or change a mode'));
+    expect(screen.getByTestId('mode-apply').textContent).toContain('claude-code');
+  });
+
+  it('renders the custom-only case with a nudge to apply a mode', () => {
+    const customOnly = [
+      { id: 'c1', name: 'Lone rule', policy_type: 'block_action_type', rules: '{}', active: 1, agent_ids: null },
+    ];
+    render(<PolicyConsole policies={customOnly} onApplied={vi.fn()} />);
+    expect(screen.getByText('Custom policies')).toBeTruthy();
+    expect(screen.getByText(/No operating mode applied yet/)).toBeTruthy();
+  });
+});

--- a/__tests__/unit/policy-mode-apply.test.jsx
+++ b/__tests__/unit/policy-mode-apply.test.jsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const h = vi.hoisted(() => ({ role: { isAdmin: true, settled: true } }));
+vi.mock('@/hooks/useEffectiveRole', () => ({ useEffectiveRole: () => h.role }));
+
+vi.mock('@/policies/lib/modesClient', () => ({
+  fetchModes: vi.fn(),
+  previewMode: vi.fn(),
+  importMode: vi.fn(),
+}));
+
+// Controllable scope picker: one click narrows scope to a single agent.
+vi.mock('@/policies/components/AgentScopePicker', () => ({
+  default: ({ agentIds = [], onChange }) => (
+    <button type="button" data-testid="pick-agent" onClick={() => onChange(['agent_1'])}>
+      scope:{agentIds.length ? agentIds.join(',') : 'all'}
+    </button>
+  ),
+}));
+
+import ModeApply from '@/policies/components/ModeApply.jsx';
+import { fetchModes, previewMode, importMode } from '@/policies/lib/modesClient';
+
+const MODES = [
+  { id: 'claude-code', name: 'Claude Code Mode', purpose: 'p', description: 'd', interruptionLevel: 'low', uxPromise: 'stays out of the way', allows: [], warns: [], requiresApproval: [], blocks: [], toolVisibilityNotes: [], policy_count: 9 },
+  { id: 'soc2', name: 'SOC 2 Mode', purpose: 'p', description: 'd', interruptionLevel: 'high', uxPromise: 'audit-ready', allows: [], warns: [], requiresApproval: [], blocks: [], toolVisibilityNotes: [], policy_count: 5 },
+];
+
+const PREVIEW = {
+  mode: {
+    id: 'claude-code', name: 'Claude Code Mode', purpose: 'p', description: 'Governs a Claude Code agent.',
+    interruptionLevel: 'low', uxPromise: 'stays out of the way',
+    allows: ['Read & edit files'], warns: ['High-risk actions'], requiresApproval: ['Deploys'], blocks: ['Extreme-risk actions'], toolVisibilityNotes: [],
+  },
+  policies: [
+    { name: '[Claude Code Mode] Warn on high-risk actions', policy_type: 'risk_threshold', decision: 'warn', rules: { threshold: 85, action: 'warn', _mode: 'claude-code' } },
+    { name: '[Claude Code Mode] Gate paid (x402) spend', policy_type: 'x402_spend_limit', decision: 'require_approval', rules: { approval_threshold: 0.01, max_spend_usd: 0.1, _mode: 'claude-code' } },
+  ],
+  summary: { total: 9, warn: 2, require_approval: 6, block: 1 },
+  friction: { available: true, sample_size: 120, window_days: 7, summary: { total: 120, allow: 100, warn: 12, require_approval: 6, block: 2 }, excluded_policy_types: ['rate_limit'] },
+};
+
+const IMPORT_RESULT = {
+  mode_id: 'claude-code', imported: 9, skipped: 0, errors: [],
+  policies: [
+    { id: 'gp_risk', name: '[Claude Code Mode] Warn on high-risk actions', policy_type: 'risk_threshold', active: 1 },
+    { id: 'gp_x402', name: '[Claude Code Mode] Gate paid (x402) spend', policy_type: 'x402_spend_limit', active: 1 },
+  ],
+};
+
+// Find a PATCH /api/policies call whose parsed body satisfies the predicate.
+// Robust against JSON-string escaping of nested `rules`/`agent_ids`.
+function findPatch(predicate) {
+  return global.fetch.mock.calls.find(([, init]) => {
+    if (init?.method !== 'PATCH') return false;
+    try { return predicate(JSON.parse(init.body)); } catch { return false; }
+  });
+}
+
+describe('ModeApply', () => {
+  beforeEach(() => {
+    h.role = { isAdmin: true, settled: true };
+    vi.mocked(fetchModes).mockResolvedValue(MODES);
+    vi.mocked(previewMode).mockResolvedValue(PREVIEW);
+    vi.mocked(importMode).mockResolvedValue(IMPORT_RESULT);
+    global.fetch = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
+  });
+  afterEach(() => { vi.clearAllMocks(); });
+
+  it('recommends Claude Code Mode and shows its compiled behavior', async () => {
+    render(<ModeApply />);
+    expect(await screen.findByRole('heading', { name: 'Claude Code Mode' })).toBeTruthy();
+    expect(screen.getByText('Recommended')).toBeTruthy();
+    expect(screen.getByText('What this mode enforces')).toBeTruthy();
+    // Behavior buckets, drawn from the compiled mode.
+    expect(screen.getByText('Read & edit files')).toBeTruthy();
+    expect(screen.getByText('Extreme-risk actions')).toBeTruthy();
+  });
+
+  it('shows the interruption forecast from real friction history', async () => {
+    render(<ModeApply />);
+    expect(await screen.findByText('Interruption forecast')).toBeTruthy();
+    // warn(12) + require_approval(6) = 18 paused of 120 sampled.
+    expect(screen.getByText('18')).toBeTruthy();
+    expect(screen.getByText('120')).toBeTruthy();
+    expect(screen.getByText(/Excluded \(not deterministically simulable\)/)).toBeTruthy();
+  });
+
+  it('shows an honest message when there is no forecast history yet', async () => {
+    vi.mocked(previewMode).mockResolvedValue({ ...PREVIEW, friction: { available: false, reason: 'No recent action history to simulate against yet.' } });
+    render(<ModeApply />);
+    expect(await screen.findByText(/No interruption forecast yet/)).toBeTruthy();
+  });
+
+  it('applies the mode in a single action', async () => {
+    const onApplied = vi.fn();
+    render(<ModeApply onApplied={onApplied} />);
+    await screen.findByText('Interruption forecast'); // gate on preview load
+    fireEvent.click(screen.getByRole('button', { name: /Apply Claude Code Mode/ }));
+    await waitFor(() => expect(vi.mocked(importMode)).toHaveBeenCalledWith('claude-code'));
+    await waitFor(() => expect(onApplied).toHaveBeenCalled());
+    expect(screen.getByText(/9 applied/)).toBeTruthy();
+    // No scope/cap change → no follow-up PATCH calls.
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('narrows scope with a PATCH when specific agents are chosen', async () => {
+    render(<ModeApply />);
+    await screen.findByLabelText('Spend cap (paid actions)'); // gate on preview load
+    fireEvent.click(screen.getByTestId('pick-agent'));
+    fireEvent.click(screen.getByRole('button', { name: /Apply Claude Code Mode/ }));
+    await waitFor(() => expect(vi.mocked(importMode)).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(findPatch((b) => String(b.agent_ids).includes('agent_1'))).toBeTruthy();
+    });
+  });
+
+  it('overrides the spend cap with a PATCH when the value changes', async () => {
+    render(<ModeApply />);
+    const cap = await screen.findByLabelText('Spend cap (paid actions)');
+    fireEvent.change(cap, { target: { value: '0.5' } });
+    fireEvent.click(screen.getByRole('button', { name: /Apply Claude Code Mode/ }));
+    await waitFor(() => {
+      expect(findPatch((b) => JSON.parse(b.rules).max_spend_usd === 0.5)).toBeTruthy();
+    });
+  });
+
+  it('blocks apply for non-admin viewers', async () => {
+    h.role = { isAdmin: false, settled: true };
+    render(<ModeApply />);
+    const apply = await screen.findByRole('button', { name: /Apply Claude Code Mode/ });
+    expect(apply.disabled).toBe(true);
+    expect(screen.getByText('Admin access required to apply a mode.')).toBeTruthy();
+  });
+});

--- a/app/policies/components/AdvancedSection.tsx
+++ b/app/policies/components/AdvancedSection.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import { Shield, FileCode, Activity } from 'lucide-react';
+import Disclosure from './Disclosure';
+import ShieldsGrid from './ShieldsGrid';
+import CustomTab from './CustomTab';
+import ActivityTab from './ActivityTab';
+
+type AdvancedView = 'shields' | 'custom' | 'activity';
+
+const VIEWS: Array<{ id: AdvancedView; label: string; icon: typeof Shield; hint: string }> = [
+  { id: 'shields', label: 'Shields', icon: Shield, hint: 'One-tap guard presets' },
+  { id: 'custom', label: 'Custom', icon: FileCode, hint: 'Author, import, AI-generate, simulate, test, proof' },
+  { id: 'activity', label: 'Activity', icon: Activity, hint: 'Live guard-decision feed' },
+];
+
+/**
+ * The "Advanced" disclosure. Demotes the former Shields / Custom / Activity
+ * tabs to a single collapsed surface: every capability is preserved (each
+ * component is self-contained and mounted unchanged), but none competes with
+ * the primary mode-apply action. The inner switcher is visually subordinate —
+ * it is not a co-equal top-level tab bar.
+ */
+export default function AdvancedSection() {
+  const [view, setView] = useState<AdvancedView>('shields');
+
+  return (
+    <Disclosure
+      summary="Advanced"
+      hint="Shields, custom policy authoring, and the decision activity feed."
+    >
+      <div className="rounded-xl border border-border bg-surface-secondary p-4">
+        <div role="tablist" aria-label="Advanced policy tools" className="flex flex-wrap gap-1.5">
+          {VIEWS.map((v) => {
+            const Icon = v.icon;
+            const active = view === v.id;
+            return (
+              <button
+                key={v.id}
+                role="tab"
+                aria-selected={active}
+                title={v.hint}
+                onClick={() => setView(v.id)}
+                className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs transition-colors ${
+                  active
+                    ? 'border-brand/40 bg-brand/10 text-brand'
+                    : 'border-white/5 bg-white/5 text-tertiary hover:text-secondary'
+                }`}
+              >
+                <Icon size={13} aria-hidden="true" />
+                {v.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mt-4">
+          {view === 'shields' && <ShieldsGrid />}
+          {view === 'custom' && <CustomTab />}
+          {view === 'activity' && <ActivityTab />}
+        </div>
+      </div>
+    </Disclosure>
+  );
+}

--- a/app/policies/components/Disclosure.tsx
+++ b/app/policies/components/Disclosure.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useId, useState, type ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+interface DisclosureProps {
+  /** Always-visible trigger label. */
+  summary: ReactNode;
+  /** Optional secondary line under the label. */
+  hint?: ReactNode;
+  /** Optional trailing element rendered on the right of the trigger. */
+  meta?: ReactNode;
+  children: ReactNode;
+  defaultOpen?: boolean;
+  /** Visual emphasis: 'panel' = bordered card trigger, 'plain' = quiet inline link. */
+  tone?: 'panel' | 'plain';
+}
+
+/**
+ * Accessible collapsible region. Trigger is a real <button> carrying
+ * aria-expanded + aria-controls; the panel is keyboard- and screen-reader
+ * addressable. Motion is a single color/transform transition, suppressed under
+ * prefers-reduced-motion.
+ */
+export default function Disclosure({ summary, hint, meta, children, defaultOpen = false, tone = 'panel' }: DisclosureProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const panelId = useId();
+
+  const triggerClass =
+    tone === 'panel'
+      ? 'flex w-full items-center gap-3 rounded-xl border border-border bg-surface-secondary px-4 py-3 text-left transition-colors hover:border-border-hover'
+      : 'flex w-full items-center gap-2 rounded-lg px-1 py-1.5 text-left text-tertiary transition-colors hover:text-secondary';
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={panelId}
+        className={triggerClass}
+      >
+        <ChevronDown
+          size={tone === 'panel' ? 16 : 14}
+          aria-hidden="true"
+          className={`shrink-0 text-tertiary transition-transform motion-reduce:transition-none ${open ? 'rotate-180' : ''}`}
+        />
+        <span className="min-w-0 flex-1">
+          <span className={tone === 'panel' ? 'block text-sm font-medium text-secondary' : 'text-xs font-medium'}>
+            {summary}
+          </span>
+          {hint && <span className="mt-0.5 block text-xs text-tertiary">{hint}</span>}
+        </span>
+        {meta && <span className="shrink-0 text-xs text-tertiary">{meta}</span>}
+      </button>
+      <div id={panelId} hidden={!open} className={tone === 'panel' ? 'mt-3' : 'mt-2'}>
+        {open && children}
+      </div>
+    </div>
+  );
+}

--- a/app/policies/components/ModeApply.tsx
+++ b/app/policies/components/ModeApply.tsx
@@ -1,0 +1,313 @@
+'use client';
+
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { Check, Eye, PauseCircle, Ban, Sparkles } from 'lucide-react';
+import { Skeleton } from '../../components/ui/Skeleton';
+import { useEffectiveRole } from '../../hooks/useEffectiveRole';
+import { fetchModes, previewMode, importMode } from '../lib/modesClient';
+import type { PolicyModeSummary, ModePreview } from '../lib/modesClient';
+import AgentScopePicker from './AgentScopePicker';
+import ModeCard from './ModeCard';
+import Disclosure from './Disclosure';
+
+/** The recommended default mode for the guided front door. */
+export const RECOMMENDED_MODE_ID = 'claude-code';
+
+const LEVEL: Record<string, { label: string; dot: string }> = {
+  low: { label: 'Low interruption', dot: 'bg-success' },
+  medium: { label: 'Medium interruption', dot: 'bg-warning' },
+  high: { label: 'High interruption', dot: 'bg-error' },
+};
+const LEVEL_FALLBACK = { label: 'Medium interruption', dot: 'bg-warning' };
+
+const GROUPS: Array<{ key: 'allows' | 'warns' | 'requiresApproval' | 'blocks'; title: string; gloss: string; icon: typeof Check; tone: string }> = [
+  { key: 'allows', title: 'Allows', gloss: 'runs without friction', icon: Check, tone: 'text-success' },
+  { key: 'warns', title: 'Warns', gloss: 'records and surfaces', icon: Eye, tone: 'text-info' },
+  { key: 'requiresApproval', title: 'Requires approval', gloss: 'pauses for a human', icon: PauseCircle, tone: 'text-warning' },
+  { key: 'blocks', title: 'Blocks', gloss: 'denies outright', icon: Ban, tone: 'text-error' },
+];
+
+const X402_TYPE = 'x402_spend_limit';
+
+async function patchPolicy(body: Record<string, unknown>): Promise<void> {
+  const res = await fetch('/api/policies', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error((data as { error?: string }).error || `Update failed (${res.status})`);
+  }
+}
+
+interface ModeApplyProps {
+  /** Mode to recommend / preselect. Defaults to Claude Code Mode. */
+  defaultModeId?: string;
+  /** Fired after a mode is applied (and any scope/cap overrides land). */
+  onApplied?: () => void;
+}
+
+/**
+ * The guided apply surface: recommends one mode, shows its compiled
+ * allow/warn/require-approval/block behavior plus a real interruption-noise
+ * forecast, collects scope + spend cap inline, and applies it in a single
+ * action. Other modes live behind a disclosure so the recommendation stays the
+ * lede. Reuses the modes engine (modesClient), AgentScopePicker, and ModeCard.
+ */
+export default function ModeApply({ defaultModeId = RECOMMENDED_MODE_ID, onApplied }: ModeApplyProps) {
+  const { isAdmin, settled } = useEffectiveRole();
+  const capFieldId = useId();
+
+  const [modes, setModes] = useState<PolicyModeSummary[]>([]);
+  const [selectedId, setSelectedId] = useState(defaultModeId);
+  const [preview, setPreview] = useState<ModePreview | null>(null);
+  const [loadingPreview, setLoadingPreview] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [agentIds, setAgentIds] = useState<string[]>([]);
+  const [capInput, setCapInput] = useState('');
+  const [capTouched, setCapTouched] = useState(false);
+
+  const [applying, setApplying] = useState(false);
+  const [applyMsg, setApplyMsg] = useState<string | null>(null);
+  const [applyErr, setApplyErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchModes().then(setModes).catch(() => { /* preview drives the primary error surface */ });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingPreview(true);
+    setError(null);
+    setApplyMsg(null);
+    setApplyErr(null);
+    setCapTouched(false);
+    previewMode(selectedId)
+      .then((p) => {
+        if (cancelled) return;
+        setPreview(p);
+        const x402 = p.policies.find((pol) => pol.policy_type === X402_TYPE);
+        const cap = x402 ? Number((x402.rules as { max_spend_usd?: number }).max_spend_usd) : NaN;
+        setCapInput(Number.isFinite(cap) ? String(cap) : '');
+      })
+      .catch((e) => { if (!cancelled) setError((e as Error).message); })
+      .finally(() => { if (!cancelled) setLoadingPreview(false); });
+    return () => { cancelled = true; };
+  }, [selectedId]);
+
+  const x402Preview = useMemo(
+    () => preview?.policies.find((p) => p.policy_type === X402_TYPE) ?? null,
+    [preview],
+  );
+  const defaultCap = x402Preview ? Number((x402Preview.rules as { max_spend_usd?: number }).max_spend_usd) : null;
+  const selectedMode = preview?.mode ?? modes.find((m) => m.id === selectedId) ?? null;
+  const level = (selectedMode ? LEVEL[selectedMode.interruptionLevel] : undefined) ?? LEVEL_FALLBACK;
+
+  const handleApply = useCallback(async () => {
+    if (!preview) return;
+    setApplying(true);
+    setApplyErr(null);
+    setApplyMsg(null);
+    try {
+      const result = await importMode(selectedId);
+      const created = (result.policies as Array<{ id: string; policy_type: string }>) ?? [];
+
+      // Scope: only narrow when specific agents were chosen (empty = all agents).
+      if (agentIds.length > 0 && created.length > 0) {
+        await Promise.all(
+          created.map((p) => patchPolicy({ id: p.id, agent_ids: JSON.stringify(agentIds) })),
+        );
+      }
+
+      // Spend cap: only patch the x402 policy when the operator changed the value.
+      const parsedCap = parseFloat(capInput);
+      if (capTouched && x402Preview && Number.isFinite(parsedCap) && parsedCap !== defaultCap) {
+        const x402Created = created.find((p) => p.policy_type === X402_TYPE);
+        if (x402Created) {
+          const nextRules = { ...(x402Preview.rules as Record<string, unknown>), max_spend_usd: parsedCap };
+          await patchPolicy({ id: x402Created.id, rules: JSON.stringify(nextRules) });
+        }
+      }
+
+      const parts = [`${result.imported} applied`];
+      if (result.skipped > 0) parts.push(`${result.skipped} already present`);
+      if (result.errors.length > 0) parts.push(`${result.errors.length} errors`);
+      setApplyMsg(parts.join(' · '));
+      onApplied?.();
+    } catch (e) {
+      setApplyErr((e as Error).message);
+    } finally {
+      setApplying(false);
+    }
+  }, [preview, selectedId, agentIds, capInput, capTouched, x402Preview, defaultCap, onApplied]);
+
+  const isRecommended = selectedId === RECOMMENDED_MODE_ID;
+
+  return (
+    <div className="rounded-xl border border-border bg-surface-secondary p-5">
+      {/* Recommendation header */}
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          {isRecommended && (
+            <span className="mb-1.5 inline-flex items-center gap-1.5 rounded-full border border-brand/30 bg-brand/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-brand">
+              <Sparkles size={11} aria-hidden="true" /> Recommended
+            </span>
+          )}
+          <h3 className="text-base font-semibold text-white">{selectedMode?.name ?? 'Loading mode…'}</h3>
+          {selectedMode && <p className="mt-1 max-w-xl text-xs leading-relaxed text-secondary">{selectedMode.description}</p>}
+        </div>
+        {selectedMode && (
+          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-border px-2.5 py-1 text-[11px] text-secondary">
+            <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${level.dot}`} />
+            {level.label}
+          </span>
+        )}
+      </div>
+
+      {/* Compiled behavior */}
+      <div className="mt-4 border-t border-border pt-4">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-tertiary">What this mode enforces</span>
+          {preview && (
+            <span className="text-[11px] tabular-nums text-tertiary">
+              <span className="text-white">{preview.summary.total}</span> rules ·{' '}
+              <span className="text-info">{preview.summary.warn}</span> warn ·{' '}
+              <span className="text-warning">{preview.summary.require_approval}</span> approval ·{' '}
+              <span className="text-error">{preview.summary.block}</span> block
+            </span>
+          )}
+        </div>
+
+        {loadingPreview && (
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-16 w-full rounded-lg" />)}
+          </div>
+        )}
+        {error && !loadingPreview && (
+          <p className="mt-3 text-xs text-error">Could not load this mode: {error}</p>
+        )}
+        {preview && !loadingPreview && (
+          <div className="mt-3 grid gap-4 sm:grid-cols-2">
+            {GROUPS.map((g) => {
+              const items = preview.mode[g.key];
+              if (!items || items.length === 0) return null;
+              const Icon = g.icon;
+              return (
+                <div key={g.key}>
+                  <div className="flex items-center gap-1.5">
+                    <Icon size={14} className={g.tone} aria-hidden="true" />
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-tertiary">{g.title}</span>
+                    <span className="text-[11px] text-disabled">{g.gloss}</span>
+                  </div>
+                  <ul className="mt-1.5 space-y-1">
+                    {items.map((item, i) => (
+                      <li key={i} className="text-xs leading-relaxed text-secondary">{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Interruption-noise forecast */}
+      {preview && !loadingPreview && (
+        <div className="mt-4 border-t border-border pt-4">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-tertiary">Interruption forecast</span>
+          {preview.friction.available ? (
+            <div className="mt-2 rounded-lg border border-border bg-surface-tertiary p-3">
+              <p className="text-xs text-secondary">
+                Replayed against your last {preview.friction.window_days} days of activity, this mode would have paused{' '}
+                <span className="font-semibold tabular-nums text-warning">
+                  {preview.friction.summary.warn + preview.friction.summary.require_approval}
+                </span>{' '}
+                of{' '}
+                <span className="font-semibold tabular-nums text-white">{preview.friction.sample_size}</span> actions
+                {preview.friction.summary.block > 0 && (
+                  <> and blocked <span className="font-semibold tabular-nums text-error">{preview.friction.summary.block}</span></>
+                )}
+                .
+              </p>
+              {preview.friction.excluded_policy_types.length > 0 && (
+                <p className="mt-1.5 text-[11px] text-tertiary">
+                  Excluded (not deterministically simulable): {preview.friction.excluded_policy_types.join(', ')}.
+                </p>
+              )}
+            </div>
+          ) : (
+            <p className="mt-2 text-xs text-tertiary">
+              No interruption forecast yet. {preview.friction.reason} This mode is rated{' '}
+              <span className="text-secondary">{level.label.toLowerCase()}</span>.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Inline required inputs: scope + spend cap */}
+      <div className="mt-4 grid gap-4 border-t border-border pt-4 sm:grid-cols-2">
+        <AgentScopePicker agentIds={agentIds} onChange={setAgentIds} />
+        <div>
+          <label htmlFor={capFieldId} className="mb-2 block text-[10px] uppercase tracking-widest text-tertiary">
+            Spend cap (paid actions)
+          </label>
+          {x402Preview ? (
+            <>
+              <div className="flex items-center gap-2 rounded-lg border border-border bg-surface-tertiary px-3 py-1.5 focus-within:border-border-active">
+                <span className="text-xs text-tertiary">$</span>
+                <input
+                  id={capFieldId}
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  inputMode="decimal"
+                  value={capInput}
+                  onChange={(e) => { setCapInput(e.target.value); setCapTouched(true); }}
+                  className="w-full bg-transparent text-xs tabular-nums text-white outline-none placeholder:text-disabled"
+                  placeholder={defaultCap != null ? String(defaultCap) : '0.10'}
+                />
+              </div>
+              <p className="mt-1.5 text-[11px] text-tertiary">Paid (x402) actions over this amount pause for approval.</p>
+            </>
+          ) : (
+            <p className="text-xs text-tertiary">This mode does not gate paid (x402) spend.</p>
+          )}
+        </div>
+      </div>
+
+      {/* Single apply action */}
+      <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-border pt-4">
+        <button
+          type="button"
+          onClick={handleApply}
+          disabled={!isAdmin || applying || loadingPreview || !preview}
+          className="rounded-lg border border-brand/40 bg-brand/10 px-4 py-2 text-xs font-medium text-brand transition-colors hover:border-brand/60 hover:bg-brand/15 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {applying ? 'Applying…' : `Apply ${selectedMode?.name ?? 'mode'}`}
+        </button>
+        {settled && !isAdmin && <span className="text-xs text-tertiary">Admin access required to apply a mode.</span>}
+        {applyMsg && <span className="text-xs text-success">{applyMsg}</span>}
+        {applyErr && <span className="text-xs text-error">{applyErr}</span>}
+      </div>
+
+      {/* Other modes — recommendation stays the lede */}
+      {modes.length > 1 && (
+        <div className="mt-4 border-t border-border pt-4">
+          <Disclosure
+            tone="plain"
+            summary={`Choose a different mode (${modes.length})`}
+            hint="Each mode compiles to a preview-able pack of guard rules. Applying is additive."
+          >
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {modes.map((m) => (
+                <ModeCard key={m.id} mode={m} selected={m.id === selectedId} onSelect={() => setSelectedId(m.id)} />
+              ))}
+            </div>
+          </Disclosure>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/policies/components/PolicyConsole.tsx
+++ b/app/policies/components/PolicyConsole.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Layers, FileCog } from 'lucide-react';
+import { POLICY_MODE_CATALOG } from '../../lib/policy-modes/catalog';
+import Disclosure from './Disclosure';
+import ModeApply, { RECOMMENDED_MODE_ID } from './ModeApply';
+import AdvancedSection from './AdvancedSection';
+
+interface PolicyRow {
+  id: string;
+  name: string;
+  policy_type: string;
+  rules: string;
+  active: number;
+  agent_ids: string | null;
+}
+
+interface PolicyConsoleProps {
+  policies: PolicyRow[];
+  /** Re-fetches policies after a mode is applied or changed. */
+  onApplied: () => void;
+}
+
+const LEVEL_DOT: Record<string, string> = { low: 'bg-success', medium: 'bg-warning', high: 'bg-error' };
+
+function parseRules(raw: string): Record<string, unknown> {
+  try { return JSON.parse(raw) as Record<string, unknown>; } catch { return {}; }
+}
+
+function parseScope(raw: string | null): string[] | null {
+  // null / empty array == all agents
+  if (!raw) return null;
+  try {
+    const ids = JSON.parse(raw);
+    return Array.isArray(ids) && ids.length > 0 ? ids : null;
+  } catch { return null; }
+}
+
+interface ModeGroup {
+  kind: 'mode';
+  modeId: string;
+  name: string;
+  level: string;
+  count: number;
+  allAgents: boolean;
+  agentIds: Set<string>;
+}
+interface CustomGroup {
+  kind: 'custom';
+  count: number;
+  allAgents: boolean;
+  agentIds: Set<string>;
+}
+
+export default function PolicyConsole({ policies, onApplied }: PolicyConsoleProps) {
+  const [agentNames, setAgentNames] = useState<Record<string, string>>({});
+  const [decisionStats, setDecisionStats] = useState<{ blocks: number; approvals: number }>({ blocks: 0, approvals: 0 });
+
+  useEffect(() => {
+    fetch('/api/agents')
+      .then((r) => (r.ok ? r.json() : { agents: [] }))
+      .then((d) => {
+        const map: Record<string, string> = {};
+        for (const a of d.agents || []) map[a.agent_id] = a.agent_name || a.agent_id;
+        setAgentNames(map);
+      })
+      .catch(() => { /* names are a nicety; ids still render */ });
+    fetch('/api/guard/decisions?limit=1')
+      .then((r) => (r.ok ? r.json() : { stats: {} }))
+      .then((d) => setDecisionStats({ blocks: d.stats?.blocks || 0, approvals: d.stats?.approvals || 0 }))
+      .catch(() => { /* stats are non-essential */ });
+  }, []);
+
+  const active = useMemo(() => policies.filter((p) => p.active === 1), [policies]);
+
+  const { modeGroups, custom, governedAgents } = useMemo(() => {
+    const modes = new Map<string, ModeGroup>();
+    const customGroup: CustomGroup = { kind: 'custom', count: 0, allAgents: false, agentIds: new Set() };
+    const governed = new Set<string>();
+
+    for (const p of active) {
+      const modeId = parseRules(p.rules)._mode as string | undefined;
+      const scope = parseScope(p.agent_ids);
+      const allAgents = scope === null;
+      if (scope) scope.forEach((id) => governed.add(id));
+
+      const meta = modeId ? POLICY_MODE_CATALOG[modeId] : undefined;
+      if (modeId && meta) {
+        const g = modes.get(modeId) ?? {
+          kind: 'mode' as const, modeId, name: meta.name, level: meta.interruptionLevel,
+          count: 0, allAgents: false, agentIds: new Set<string>(),
+        };
+        g.count += 1;
+        g.allAgents = g.allAgents || allAgents;
+        if (scope) scope.forEach((id) => g.agentIds.add(id));
+        modes.set(modeId, g);
+      } else {
+        customGroup.count += 1;
+        customGroup.allAgents = customGroup.allAgents || allAgents;
+        if (scope) scope.forEach((id) => customGroup.agentIds.add(id));
+      }
+    }
+    return { modeGroups: [...modes.values()], custom: customGroup, governedAgents: governed };
+  }, [active]);
+
+  const primaryModeId = modeGroups[0]?.modeId ?? RECOMMENDED_MODE_ID;
+
+  const scopeLabel = (allAgents: boolean, ids: Set<string>) => {
+    if (allAgents || ids.size === 0) return 'All agents';
+    const names = [...ids].map((id) => agentNames[id] || id);
+    return names.length <= 2 ? names.join(', ') : `${names.slice(0, 2).join(', ')} +${names.length - 2}`;
+  };
+
+  return (
+    <div className="space-y-5">
+      {/* Stat rail — prose, not a card grid */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-secondary">
+        <span><span className="font-semibold tabular-nums text-white">{active.length}</span> active {active.length === 1 ? 'policy' : 'policies'}</span>
+        <span aria-hidden="true" className="text-zinc-700">&middot;</span>
+        <span><span className="font-semibold tabular-nums text-error">{decisionStats.blocks}</span> blocks this week</span>
+        <span aria-hidden="true" className="text-zinc-700">&middot;</span>
+        <span><span className="font-semibold tabular-nums text-warning">{decisionStats.approvals}</span> approvals this week</span>
+        <span aria-hidden="true" className="text-zinc-700">&middot;</span>
+        <span>
+          {governedAgents.size > 0
+            ? <><span className="font-semibold tabular-nums text-white">{governedAgents.size}</span> agents scoped</>
+            : <span className="text-tertiary">all agents governed</span>}
+        </span>
+      </div>
+
+      {/* Governance summary */}
+      <section className="rounded-xl border border-border bg-surface-secondary p-5">
+        <h2 className="text-sm font-semibold text-white">What is governing your agents</h2>
+        <ul className="mt-3 divide-y divide-border overflow-hidden rounded-lg border border-border">
+          {modeGroups.map((g) => (
+            <li key={g.modeId} className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+              <div className="flex min-w-0 items-center gap-2.5">
+                <span aria-hidden="true" className={`h-2 w-2 shrink-0 rounded-full ${LEVEL_DOT[g.level] ?? 'bg-warning'}`} />
+                <span className="truncate text-sm text-white">{g.name}</span>
+                <span className="text-[11px] text-tertiary">{g.level} interruption</span>
+              </div>
+              <div className="flex items-center gap-3 text-xs tabular-nums text-tertiary">
+                <span>{`${g.count} ${g.count === 1 ? 'rule' : 'rules'}`}</span>
+                <span aria-hidden="true" className="text-zinc-700">&middot;</span>
+                <span className="text-secondary">{scopeLabel(g.allAgents, g.agentIds)}</span>
+              </div>
+            </li>
+          ))}
+          {custom.count > 0 && (
+            <li className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+              <div className="flex min-w-0 items-center gap-2.5">
+                <FileCog size={14} aria-hidden="true" className="shrink-0 text-tertiary" />
+                <span className="truncate text-sm text-white">Custom policies</span>
+                <span className="text-[11px] text-tertiary">authored or imported</span>
+              </div>
+              <div className="flex items-center gap-3 text-xs tabular-nums text-tertiary">
+                <span>{`${custom.count} ${custom.count === 1 ? 'rule' : 'rules'}`}</span>
+                <span aria-hidden="true" className="text-zinc-700">&middot;</span>
+                <span className="text-secondary">{scopeLabel(custom.allAgents, custom.agentIds)}</span>
+              </div>
+            </li>
+          )}
+        </ul>
+
+        {modeGroups.length === 0 && custom.count > 0 && (
+          <p className="mt-3 flex items-center gap-1.5 text-xs text-tertiary">
+            <Layers size={13} aria-hidden="true" />
+            No operating mode applied yet. Apply one below to cover the common cases in one step.
+          </p>
+        )}
+      </section>
+
+      {/* Primary action: apply or change a mode */}
+      <Disclosure
+        summary="Apply or change a mode"
+        hint="Swap operating modes or apply another. Applying is additive and previewable."
+      >
+        <ModeApply defaultModeId={primaryModeId} onApplied={onApplied} />
+      </Disclosure>
+
+      {/* Everything else, demoted */}
+      <AdvancedSection />
+    </div>
+  );
+}

--- a/app/policies/components/PolicyFrontDoor.tsx
+++ b/app/policies/components/PolicyFrontDoor.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ShieldCheck } from 'lucide-react';
+import ModeApply from './ModeApply';
+import AdvancedSection from './AdvancedSection';
+
+interface PolicyFrontDoorProps {
+  /** Re-checks governance state after a mode is applied (zero → populated). */
+  onApplied: () => void;
+}
+
+/**
+ * Zero-policy state: the guided front door. One opinionated screen, not a
+ * wizard. It recommends Claude Code Mode, shows exactly what that will enforce
+ * plus the interruption forecast, takes scope + spend cap inline, and applies
+ * in a single action. Manual authoring stays reachable, demoted to Advanced.
+ */
+export default function PolicyFrontDoor({ onApplied }: PolicyFrontDoorProps) {
+  return (
+    <div className="max-w-3xl space-y-5">
+      <div className="flex items-start gap-3">
+        <span aria-hidden="true" className="mt-0.5 rounded-lg border border-border bg-surface-secondary p-2 text-brand">
+          <ShieldCheck size={18} />
+        </span>
+        <div>
+          <h2 className="text-lg font-semibold text-white">No policies are governing your agents yet</h2>
+          <p className="mt-1 text-sm leading-relaxed text-secondary">
+            Start with an operating mode. It compiles to a pack of guard rules you can read before applying, so
+            governance is one decision instead of a blank policy editor.
+          </p>
+        </div>
+      </div>
+
+      <ModeApply onApplied={onApplied} />
+
+      <AdvancedSection />
+    </div>
+  );
+}

--- a/app/policies/page.tsx
+++ b/app/policies/page.tsx
@@ -1,98 +1,54 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import PageLayout from '../components/PageLayout';
-import ModesTab from './components/ModesTab';
-import ShieldsGrid from './components/ShieldsGrid';
-import CustomTab from './components/CustomTab';
-import ActivityTab from './components/ActivityTab';
+import { Skeleton } from '../components/ui/Skeleton';
+import PolicyFrontDoor from './components/PolicyFrontDoor';
+import PolicyConsole from './components/PolicyConsole';
 
-const TABS = [
-  { id: 'modes', label: 'Modes' },
-  { id: 'shields', label: 'Shields' },
-  { id: 'custom', label: 'Custom' },
-  { id: 'activity', label: 'Activity' },
-];
-
-interface PolicyStats {
+interface PolicyRow {
+  id: string;
+  name: string;
+  policy_type: string;
+  rules: string;
   active: number;
-  blocks: number;
-  approvals: number;
-  agents: number;
+  agent_ids: string | null;
 }
 
 export default function PoliciesPage() {
-  const [activeTab, setActiveTab] = useState('modes');
-  const [stats, setStats] = useState<PolicyStats>({ active: 0, blocks: 0, approvals: 0, agents: 0 });
+  const [policies, setPolicies] = useState<PolicyRow[] | null>(null);
 
-  useEffect(() => {
-    const fetchStats = async () => {
-      try {
-        const [policiesRes, decisionsRes, agentsRes] = await Promise.all([
-          fetch('/api/policies'),
-          fetch('/api/guard/decisions?limit=1'),
-          fetch('/api/agents'),
-        ]);
-        const policiesData = policiesRes.ok ? await policiesRes.json() : { policies: [] };
-        const decisionsData = decisionsRes.ok ? await decisionsRes.json() : { stats: {} };
-        const agentsData = agentsRes.ok ? await agentsRes.json() : { agents: [] };
-        setStats({
-          active: (policiesData.policies || []).filter((p: any) => p.active === 1).length,
-          blocks: decisionsData.stats?.blocks || 0,
-          approvals: decisionsData.stats?.approvals || 0,
-          agents: (agentsData.agents || []).length,
-        });
-      } catch { /* ignore */ }
-    };
-    fetchStats();
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/policies');
+      const data = res.ok ? await res.json() : { policies: [] };
+      setPolicies((data.policies as PolicyRow[]) || []);
+    } catch {
+      setPolicies([]);
+    }
   }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const hasGovernance = policies != null && policies.some((p) => p.active === 1);
 
   return (
     <PageLayout
       title="Policies"
-      subtitle="Governance shields and guard rules"
+      subtitle="Govern your agents with one decision"
       breadcrumbs={['Governance', 'Policies']}
       maturity="stable"
     >
-      {/* Stats bar — prose rail, not another card grid */}
-      <div className="mb-6 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-secondary">
-        <span><span className="font-semibold tabular-nums text-white">{stats.active}</span> active shields</span>
-        <span aria-hidden="true" className="text-zinc-700">&middot;</span>
-        <span><span className="font-semibold tabular-nums text-error">{stats.blocks}</span> blocks this week</span>
-        <span aria-hidden="true" className="text-zinc-700">&middot;</span>
-        <span><span className="font-semibold tabular-nums text-warning">{stats.approvals}</span> approvals this week</span>
-        <span aria-hidden="true" className="text-zinc-700">&middot;</span>
-        <span><span className="font-semibold tabular-nums text-white">{stats.agents}</span> agents governed</span>
-      </div>
-
-      {/* Tabs */}
-      <div role="tablist" className="mb-6 flex items-center gap-1 border-b border-border">
-        {TABS.map(tab => {
-          const isActive = activeTab === tab.id;
-          return (
-            <button
-              key={tab.id}
-              role="tab"
-              aria-selected={isActive}
-              onClick={() => setActiveTab(tab.id)}
-              className={`relative px-4 py-2.5 text-sm font-medium transition-colors ${
-                isActive ? 'text-white' : 'text-tertiary hover:text-secondary'
-              }`}
-            >
-              {tab.label}
-              {isActive && (
-                <span aria-hidden="true" className="absolute inset-x-0 -bottom-px h-0.5 rounded-full bg-brand" />
-              )}
-            </button>
-          );
-        })}
-      </div>
-
-      {/* Tab content */}
-      {activeTab === 'modes' && <ModesTab />}
-      {activeTab === 'shields' && <ShieldsGrid />}
-      {activeTab === 'custom' && <CustomTab />}
-      {activeTab === 'activity' && <ActivityTab />}
+      {policies == null ? (
+        <div className="max-w-3xl space-y-4">
+          <Skeleton className="h-24 w-full rounded-xl" />
+          <Skeleton className="h-64 w-full rounded-xl" />
+        </div>
+      ) : hasGovernance ? (
+        <PolicyConsole policies={policies} onApplied={load} />
+      ) : (
+        <PolicyFrontDoor onApplied={load} />
+      )}
     </PageLayout>
   );
 }

--- a/contracts/sdk/release-plan.json
+++ b/contracts/sdk/release-plan.json
@@ -1,14 +1,14 @@
 {
   "node": {
-    "current_version": "4.4.2",
+    "current_version": "4.4.3",
     "next_bump": "none",
-    "reason": "4.4.2 bundles the UI readability/brightness lift (token-layer theme pass) and the dashboard-issues resolution pass: capability/webhook undici fetch fix, dashboard layout self-heal, agent-session backfill (drizzle 0024), drift metric filter, Quality sidebar highlight, message-reply 403 fix, eval_scorers migration (0025), skill auto-scan, the learning AGENTS.md/CLAUDE.md export route, the dashclaw_assumption_record MCP tool (tools 28->29), and the messages facelift. Node SDK surface is unchanged at 126 (byte-identical to 4.4.1) and republishes at 4.4.2 per the unified-version model. Self-dep stays ^4.0.0 (within the major).",
-    "domains": ["ui", "docs"]
+    "reason": "4.4.3 ships the /policies information-architecture redesign: the flat four-tab bar (Modes/Shields/Custom/Activity) is replaced by a guided zero-state front door (recommends Claude Code Mode, shows compiled allow/warn/require-approval/block behavior + an interruption forecast, applies with inline agent scope + spend cap in one action) and a consolidated populated console (which modes/policies govern which agents + an apply/change-mode action), with Shields, Custom (authoring/import/AI-generate/simulate/test/proof), and the Activity feed demoted intact into an Advanced disclosure. Pure UX reorganization that reuses the existing modes engine, guard, and /api/policies (scope/cap via the existing PATCH); no new routes, SDK methods, MCP tools, guard policies, or schema. Node SDK surface unchanged at 126 (byte-identical to 4.4.2) and republishes at 4.4.3 per the unified-version model. Self-dep stays ^4.0.0 (within the major).",
+    "domains": ["ui"]
   },
   "python": {
-    "current_version": "4.4.2",
+    "current_version": "4.4.3",
     "next_bump": "none",
-    "reason": "4.4.2 bundles the UI readability/brightness lift and the dashboard-issues resolution pass (new platform route + dashclaw_assumption_record MCP tool + bug fixes + migrations 0024/0025). Python SDK surface is unchanged at 224 (byte-identical to 4.4.1) and republishes at 4.4.2 per the unified-version model.",
-    "domains": ["ui", "docs"]
+    "reason": "4.4.3 ships the /policies information-architecture redesign (UI-only reorganization, no new platform/SDK surface). Python SDK surface unchanged at 224 (byte-identical to 4.4.2) and republishes at 4.4.3 per the unified-version model.",
+    "domains": ["ui"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashclaw-platform",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashclaw-platform",
-      "version": "4.4.2",
+      "version": "4.4.3",
       "license": "MIT",
       "dependencies": {
         "@e965/xlsx": "^0.20.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashclaw-platform",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Decision infrastructure for AI agents — governance runtime with policy enforcement, decision recording, and human-in-the-loop approval.",
   "private": true,
   "license": "MIT",

--- a/sdk-python/pyproject.toml
+++ b/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dashclaw"
-version = "4.4.2"
+version = "4.4.3"
 description = "Python SDK for the DashClaw AI agent decision infrastructure platform"
 readme = "README.md"
 license = { text = "MIT" }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashclaw",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Minimal governance runtime for AI agents. Intercept, govern, and verify agent actions.",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
## What

Redesigns `/policies` so a new operator knows where to start. The flat four co-equal tabs (`Modes · Shields · Custom · Activity`) with no entry point are replaced by a two-state surface:

- **Zero-policy → guided front door** (one screen, not a wizard): Claude Code Mode recommended, its compiled allow/warn/require-approval/block behavior + a real interruption forecast (`previewMode().friction`, honest when there's no history), with agent **scope** and a **spend cap** inline and a single **Apply**.
- **Populated → consolidated console**: a calm summary of which modes/policies govern which agents, plus an apply/change-mode action.
- Shields, Custom (authoring, raw YAML import, AI-generate, simulate, test, proof) and the Activity feed are **demoted intact** into a labeled **Advanced** disclosure — every capability preserved.

## How

Pure UX/information-architecture reorganization. Reuses the modes engine, guard, and `/api/policies` (scope/cap applied through the existing `PATCH`). **No new routes, SDK methods, MCP tools, guard policies, or schema.** Unified version bumped to **4.4.3** (UI-only patch).

## Verification

- `tsc --noEmit`: 0 errors · `npm run build` (webpack): exit 0
- New tests: 16 across 4 files (front-door recommend/behavior/forecast/apply-with-scope+cap/admin-gate; console grouping; Advanced preserves all three surfaces; page state machine)
- Contract checks: route-sql ✓ · openapi ✓ · api-inventory ✓ · version ✓ · version:sync ✓ (4.4.3)
- Full suite green except 4 known worktree-CRLF artifacts (pass under LF) + 1 pre-existing order-flake (`eval.test.js`, passes isolated, identical to main) — none mine

## Follow-up

Owner runs `npm run release:sdks` to publish the Node + Python SDKs at 4.4.3 (credential-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
