### PR TITLE
Weekly health digest — 2026-06-15

### DIFF
--- a/.organism/digests/2026-06-15.md
+++ b/.organism/digests/2026-06-15.md
@@ -1,0 +1,47 @@
+# Weekly Health Digest — 2026-06-15
+
+**Coverage:** This week vs 2026-06-08.
+
+## What got worse
+
+- JS dependency vulnerabilities: 4 vs 0. New audit findings landed this week. Triage `npm audit` and pin the affected transitive deps.
+- Files over 300 lines: 210 vs 158 (+52). Python files over 300 also rose, 44 vs 30.
+- `mcp-server/test/providers.test.ts` jumped into the top-10 at 3334 lines, displacing `app/docs/page.tsx` as the largest file.
+- Three existing files crossed or extended past the 1500-line mark: `sdk/dashclaw.js` (1539 to 1859), `actions.repository.ts` (1366 to 1751), `middleware.js` (1615 to 1724).
+
+## What got better
+
+- Files changed in last 7 days: 31 vs 214. Smaller, more focused change footprint.
+- JS outdated packages: 28 vs 31. Modest tightening of the dependency set.
+- TODO count remains at 0 and untested routes remains at 0.
+
+## New untested routes
+
+None.
+
+## Current state concerns
+
+- CI pass rate below 80% over 30 days (current 0.0%, last-10 runs: empty — no recorded runs, signal still absent).
+- JS dependency vulnerabilities greater than 0 (current count: 4).
+- Files over 300 lines exceed baseline + 10% (current 210 vs 2026-04-20 baseline 109; 10% threshold is 120).
+- `mcp-server/test/providers.test.ts` over 2000 lines (3334 lines).
+- `app/docs/page.tsx` over 2000 lines (3265 lines).
+- `sdk/legacy/dashclaw-v1.js` over 2000 lines (2960 lines; deprecated, removed in v5.0.0).
+- `mcp-server/src/provider-actions.ts` over 2000 lines (2793 lines).
+
+## One thing to do this week
+
+Run `npm audit` against the project root and resolve the 4 new vulnerabilities. The lockfile is fresh (0 days old), so a targeted bump of the offending transitive packages should close them without dependency churn. Bounded scope, well under 4 hours, and it clears the only current-state concern that genuinely regressed.
+
+## Raw deltas
+
+| Metric | This week | Last week | Delta |
+|---|---|---|---|
+| CI pass rate 30d | 0.0% | 0.0% | 0 |
+| Last 10 CI runs | empty | empty | unchanged |
+| Files over 300 lines | 210 | 158 | +52 |
+| Untested routes | 0 | 0 | 0 |
+| JS vulnerabilities | 4 | 0 | +4 |
+| Lockfile age (days) | 0 | 0 | 0 |
+| Commits in last 7d | 50 | 50 | 0 |
+| TODO count | 0 | 0 | 0 |

--- a/.organism/digests/last-week-state.json
+++ b/.organism/digests/last-week-state.json
@@ -1,6 +1,6 @@
 {
   "organism": "dashclaw",
-  "timestamp": "2026-06-08T13:10:01.181116+00:00",
+  "timestamp": "2026-06-15T13:04:02.079864+00:00",
   "collector_status": {
     "git_stats": "ok",
     "test_health": "ok",
@@ -20,7 +20,7 @@
         "commits": 50
       }
     ],
-    "files_changed_7d": 214
+    "files_changed_7d": 31
   },
   "test_health": {
     "js_tests": {
@@ -33,62 +33,62 @@
       "passed": 0,
       "failed": 0
     },
-    "test_file_ratio": 0.36131687242798355,
+    "test_file_ratio": 0.38330046022353714,
     "untested_routes": []
   },
   "code_quality": {
-    "files_over_300_lines": 158,
+    "files_over_300_lines": 210,
     "largest_files": [
       {
+        "path": "mcp-server/test/providers.test.ts",
+        "lines": 3334
+      },
+      {
         "path": "app/docs/page.tsx",
-        "lines": 3066
+        "lines": 3265
       },
       {
         "path": "sdk/legacy/dashclaw-v1.js",
         "lines": 2960
       },
       {
-        "path": "middleware.js",
-        "lines": 1615
+        "path": "mcp-server/src/provider-actions.ts",
+        "lines": 2793
+      },
+      {
+        "path": "mcp-server/src/tools/index.ts",
+        "lines": 1996
       },
       {
         "path": "sdk/dashclaw.js",
-        "lines": 1539
+        "lines": 1859
       },
       {
-        "path": "schema/schema.js",
-        "lines": 1438
+        "path": "mcp-server/lib/provider-actions.js",
+        "lines": 1825
       },
       {
         "path": "app/lib/repositories/actions.repository.ts",
-        "lines": 1366
+        "lines": 1751
       },
       {
-        "path": "app/decisions/[actionId]/page.tsx",
-        "lines": 1271
+        "path": "middleware.js",
+        "lines": 1724
       },
       {
-        "path": "app/lib/demo/demoMiddleware.ts",
-        "lines": 1181
-      },
-      {
-        "path": "cli/bin/dashclaw.js",
-        "lines": 1163
-      },
-      {
-        "path": "packages/openclaw-plugin/src/index.ts",
-        "lines": 1115
+        "path": "app/lib/guard.ts",
+        "lines": 1682
       }
     ],
     "eslint_status": "fail",
-    "python_files_over_300": 30,
+    "python_files_over_300": 44,
     "todo_count": 0,
     "archive_size_kb": 151
   },
   "dependency_health": {
-    "js_dependencies": 51,
-    "js_outdated": 31,
-    "js_vulnerabilities": 0,
+    "js_dependencies": 48,
+    "js_outdated": 28,
+    "js_vulnerabilities": 4,
     "python_dependencies": 0,
     "lockfile_age_days": 0
   },


### PR DESCRIPTION
## What got worse

- JS dependency vulnerabilities: 4 vs 0. New audit findings landed this week. Triage `npm audit` and pin the affected transitive deps.
- Files over 300 lines: 210 vs 158 (+52). Python files over 300 also rose, 44 vs 30.
- `mcp-server/test/providers.test.ts` jumped into the top-10 at 3334 lines, displacing `app/docs/page.tsx` as the largest file.
- Three existing files crossed or extended past the 1500-line mark: `sdk/dashclaw.js` (1539 to 1859), `actions.repository.ts` (1366 to 1751), `middleware.js` (1615 to 1724).

## What got better

- Files changed in last 7 days: 31 vs 214. Smaller, more focused change footprint.
- JS outdated packages: 28 vs 31. Modest tightening of the dependency set.
- TODO count remains at 0 and untested routes remains at 0.

## New untested routes

None.

## Current state concerns

- CI pass rate below 80% over 30 days (current 0.0%, last-10 runs: empty — no recorded runs, signal still absent).
- JS dependency vulnerabilities greater than 0 (current count: 4).
- Files over 300 lines exceed baseline + 10% (current 210 vs 2026-04-20 baseline 109; 10% threshold is 120).
- `mcp-server/test/providers.test.ts` over 2000 lines (3334 lines).
- `app/docs/page.tsx` over 2000 lines (3265 lines).
- `sdk/legacy/dashclaw-v1.js` over 2000 lines (2960 lines; deprecated, removed in v5.0.0).
- `mcp-server/src/provider-actions.ts` over 2000 lines (2793 lines).

## One thing to do this week

Run `npm audit` against the project root and resolve the 4 new vulnerabilities. The lockfile is fresh (0 days old), so a targeted bump of the offending transitive packages should close them without dependency churn. Bounded scope, well under 4 hours, and it clears the only current-state concern that genuinely regressed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0188JHzsvidgt4quuZ2m82Gi)_