### PR TITLE
Weekly health digest — 2026-06-22

### DIFF
--- a/.organism/digests/2026-06-22.md
+++ b/.organism/digests/2026-06-22.md
@@ -1,0 +1,44 @@
+# Weekly Health Digest — 2026-06-22
+
+**Coverage:** This week vs 2026-06-08.
+
+## What got worse
+
+- Files over 300 lines: 211 vs 158. Net +53, driven by four new `mcp-server/*` entrants in the top-10 (`test/providers.test.ts` 3334, `src/provider-actions.ts` 2793, `src/tools/index.ts` 1996, `lib/provider-actions.js` 1825).
+- JS vulnerabilities: 1 vs 0. Audit is no longer clean; `npm audit` will name the advisory.
+- `app/docs/page.tsx` grew again (3066 to 3265). `middleware.js` (1615 to 1724) and `actions.repository.ts` (1366 to 1751) both grew materially.
+
+## What got better
+
+- Test-to-source file ratio: 0.38 vs 0.36. Small but real; the new 3334-line `providers.test.ts` is what nudged the ratio.
+
+## New untested routes
+
+None.
+
+## Current state concerns
+
+- CI pass rate below 80% over 30 days (current 0.0%, last-10 runs: empty; no recorded runs, signal is absent rather than failing).
+- JS dependency vulnerabilities greater than 0 (current 1).
+- Files over 300 lines exceed baseline + 10% (current 211 vs 2026-06-08 baseline 158; 10% threshold is 174).
+- `mcp-server/test/providers.test.ts` over 2000 lines (3334).
+- `app/docs/page.tsx` over 2000 lines (3265).
+- `sdk/legacy/dashclaw-v1.js` over 2000 lines (2960; deprecated, removed in v5.0.0).
+- `mcp-server/src/provider-actions.ts` over 2000 lines (2793).
+
+## One thing to do this week
+
+Patch the new JS advisory. Run `npm audit` to name it (lockfile is fresh, so the regression landed this week), apply `npm audit fix` if it resolves cleanly, otherwise bump the specific dep and rerun. Under 4 hours, returns the audit to 0, and forecloses the easy cause before it compounds.
+
+## Raw deltas
+
+| Metric | This week | Last week | Delta |
+|---|---|---|---|
+| CI pass rate 30d | 0.0% | 0.0% | 0 |
+| Last 10 CI runs | empty | empty | unchanged |
+| Files over 300 lines | 211 | 158 | +53 |
+| Untested routes | 0 | 0 | 0 |
+| JS vulnerabilities | 1 | 0 | +1 |
+| Lockfile age (days) | 0 | 0 | 0 |
+| Commits in last 7d | 10 | 50 | -40 |
+| TODO count | 0 | 0 | 0 |

--- a/.organism/digests/last-week-state.json
+++ b/.organism/digests/last-week-state.json
@@ -1,6 +1,6 @@
 {
   "organism": "dashclaw",
-  "timestamp": "2026-06-08T13:10:01.181116+00:00",
+  "timestamp": "2026-06-22T13:01:26.105553+00:00",
   "collector_status": {
     "git_stats": "ok",
     "test_health": "ok",
@@ -9,7 +9,7 @@
     "ci_health": "ok"
   },
   "git_stats": {
-    "commits_7d": 50,
+    "commits_7d": 10,
     "commits_30d": 50,
     "active_branches": 2,
     "stale_branches": 0,
@@ -17,10 +17,14 @@
     "top_contributors_30d": [
       {
         "name": "Wes Sander",
-        "commits": 50
+        "commits": 49
+      },
+      {
+        "name": "dependabot[bot]",
+        "commits": 1
       }
     ],
-    "files_changed_7d": 214
+    "files_changed_7d": 64
   },
   "test_health": {
     "js_tests": {
@@ -33,62 +37,62 @@
       "passed": 0,
       "failed": 0
     },
-    "test_file_ratio": 0.36131687242798355,
+    "test_file_ratio": 0.38370565045992117,
     "untested_routes": []
   },
   "code_quality": {
-    "files_over_300_lines": 158,
+    "files_over_300_lines": 211,
     "largest_files": [
       {
+        "path": "mcp-server/test/providers.test.ts",
+        "lines": 3334
+      },
+      {
         "path": "app/docs/page.tsx",
-        "lines": 3066
+        "lines": 3265
       },
       {
         "path": "sdk/legacy/dashclaw-v1.js",
         "lines": 2960
       },
       {
-        "path": "middleware.js",
-        "lines": 1615
+        "path": "mcp-server/src/provider-actions.ts",
+        "lines": 2793
+      },
+      {
+        "path": "mcp-server/src/tools/index.ts",
+        "lines": 1996
       },
       {
         "path": "sdk/dashclaw.js",
-        "lines": 1539
+        "lines": 1972
       },
       {
-        "path": "schema/schema.js",
-        "lines": 1438
+        "path": "mcp-server/lib/provider-actions.js",
+        "lines": 1825
       },
       {
         "path": "app/lib/repositories/actions.repository.ts",
-        "lines": 1366
+        "lines": 1751
       },
       {
-        "path": "app/decisions/[actionId]/page.tsx",
-        "lines": 1271
+        "path": "middleware.js",
+        "lines": 1724
       },
       {
-        "path": "app/lib/demo/demoMiddleware.ts",
-        "lines": 1181
-      },
-      {
-        "path": "cli/bin/dashclaw.js",
-        "lines": 1163
-      },
-      {
-        "path": "packages/openclaw-plugin/src/index.ts",
-        "lines": 1115
+        "path": "app/lib/guard.ts",
+        "lines": 1682
       }
     ],
     "eslint_status": "fail",
-    "python_files_over_300": 30,
+    "python_files_over_300": 44,
     "todo_count": 0,
     "archive_size_kb": 151
   },
   "dependency_health": {
-    "js_dependencies": 51,
-    "js_outdated": 31,
-    "js_vulnerabilities": 0,
+    "js_dependencies": 48,
+    "js_outdated": 28,
+    "js_vulnerabilities": 1,
     "python_dependencies": 0,
     "lockfile_age_days": 0
   },


### PR DESCRIPTION
## What got worse

- Files over 300 lines: 211 vs 158. Net +53, driven by four new `mcp-server/*` entrants in the top-10 (`test/providers.test.ts` 3334, `src/provider-actions.ts` 2793, `src/tools/index.ts` 1996, `lib/provider-actions.js` 1825).
- JS vulnerabilities: 1 vs 0. Audit is no longer clean; `npm audit` will name the advisory.
- `app/docs/page.tsx` grew again (3066 to 3265). `middleware.js` (1615 to 1724) and `actions.repository.ts` (1366 to 1751) both grew materially.

## What got better

- Test-to-source file ratio: 0.38 vs 0.36. Small but real; the new 3334-line `providers.test.ts` is what nudged the ratio.

## New untested routes

None.

## Current state concerns

- CI pass rate below 80% over 30 days (current 0.0%, last-10 runs: empty; no recorded runs, signal is absent rather than failing).
- JS dependency vulnerabilities greater than 0 (current 1).
- Files over 300 lines exceed baseline + 10% (current 211 vs 2026-06-08 baseline 158; 10% threshold is 174).
- `mcp-server/test/providers.test.ts` over 2000 lines (3334).
- `app/docs/page.tsx` over 2000 lines (3265).
- `sdk/legacy/dashclaw-v1.js` over 2000 lines (2960; deprecated, removed in v5.0.0).
- `mcp-server/src/provider-actions.ts` over 2000 lines (2793).

## One thing to do this week

Patch the new JS advisory. Run `npm audit` to name it (lockfile is fresh, so the regression landed this week), apply `npm audit fix` if it resolves cleanly, otherwise bump the specific dep and rerun. Under 4 hours, returns the audit to 0, and forecloses the easy cause before it compounds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PemKSw8cepypZkTESu83vJ)_