### PR TITLE
Weekly health digest — 2026-06-29

### DIFF
--- a/.organism/digests/2026-06-29.md
+++ b/.organism/digests/2026-06-29.md
@@ -1,0 +1,16 @@
+# Weekly Health Digest — 2026-06-29
+
+**Coverage:** This week vs 2026-06-08.
+
+Quiet week: zero commits in the last 7 days. No git activity to diff against, so the delta sections are skipped. Current-state concerns and the recommended action are still surfaced below from the fresh sense report.
+
+## Current state concerns
+
+- CI pass rate 30d sits at 0.0% with an empty last-10-runs list. The number reads alarming but reflects zero observed runs rather than a sweep of failures. Verify the CI collector is wired to the right workflow before treating this as a real regression.
+- JS dependency vulnerabilities: 1 (up from 0 at the 2026-06-08 baseline). Identify and patch via `npm audit`.
+- Files over 300 lines: 211 vs baseline 158 (+33.5%, well past the +10% threshold). Largest contributor is new growth in `mcp-server/`.
+- Largest files over 2000 lines: `mcp-server/test/providers.test.ts` (3334), `app/docs/page.tsx` (3265), `sdk/legacy/dashclaw-v1.js` (2960), `mcp-server/src/provider-actions.ts` (2793). The test file is now the single biggest file in the repo.
+
+## One thing to do this week
+
+Run `npm audit` to identify the single JS vulnerability that appeared since 2026-06-08, then `npm audit fix` (or a manual bump on the offending package). One vulnerability with a 7-day-old lockfile is the cheapest item to clear and prevents the count from compounding next week. Budget: under 1 hour including verification.

--- a/.organism/digests/last-week-state.json
+++ b/.organism/digests/last-week-state.json
@@ -1,6 +1,6 @@
 {
   "organism": "dashclaw",
-  "timestamp": "2026-06-08T13:10:01.181116+00:00",
+  "timestamp": "2026-06-29T13:01:11.284463+00:00",
   "collector_status": {
     "git_stats": "ok",
     "test_health": "ok",
@@ -9,7 +9,7 @@
     "ci_health": "ok"
   },
   "git_stats": {
-    "commits_7d": 50,
+    "commits_7d": 0,
     "commits_30d": 50,
     "active_branches": 2,
     "stale_branches": 0,
@@ -17,10 +17,14 @@
     "top_contributors_30d": [
       {
         "name": "Wes Sander",
-        "commits": 50
+        "commits": 49
+      },
+      {
+        "name": "dependabot[bot]",
+        "commits": 1
       }
     ],
-    "files_changed_7d": 214
+    "files_changed_7d": 64
   },
   "test_health": {
     "js_tests": {
@@ -33,64 +37,64 @@
       "passed": 0,
       "failed": 0
     },
-    "test_file_ratio": 0.36131687242798355,
+    "test_file_ratio": 0.38446346280447663,
     "untested_routes": []
   },
   "code_quality": {
-    "files_over_300_lines": 158,
+    "files_over_300_lines": 211,
     "largest_files": [
       {
+        "path": "mcp-server/test/providers.test.ts",
+        "lines": 3334
+      },
+      {
         "path": "app/docs/page.tsx",
-        "lines": 3066
+        "lines": 3265
       },
       {
         "path": "sdk/legacy/dashclaw-v1.js",
         "lines": 2960
       },
       {
-        "path": "middleware.js",
-        "lines": 1615
+        "path": "mcp-server/src/provider-actions.ts",
+        "lines": 2793
+      },
+      {
+        "path": "mcp-server/src/tools/index.ts",
+        "lines": 1996
       },
       {
         "path": "sdk/dashclaw.js",
-        "lines": 1539
+        "lines": 1972
       },
       {
-        "path": "schema/schema.js",
-        "lines": 1438
+        "path": "mcp-server/lib/provider-actions.js",
+        "lines": 1825
       },
       {
         "path": "app/lib/repositories/actions.repository.ts",
-        "lines": 1366
+        "lines": 1751
       },
       {
-        "path": "app/decisions/[actionId]/page.tsx",
-        "lines": 1271
+        "path": "middleware.js",
+        "lines": 1724
       },
       {
-        "path": "app/lib/demo/demoMiddleware.ts",
-        "lines": 1181
-      },
-      {
-        "path": "cli/bin/dashclaw.js",
-        "lines": 1163
-      },
-      {
-        "path": "packages/openclaw-plugin/src/index.ts",
-        "lines": 1115
+        "path": "app/lib/guard.ts",
+        "lines": 1682
       }
     ],
     "eslint_status": "fail",
-    "python_files_over_300": 30,
+    "python_files_over_300": 41,
     "todo_count": 0,
     "archive_size_kb": 151
   },
   "dependency_health": {
-    "js_dependencies": 51,
-    "js_outdated": 31,
-    "js_vulnerabilities": 0,
+    "js_dependencies": 48,
+    "js_outdated": 28,
+    "js_vulnerabilities": 1,
     "python_dependencies": 0,
-    "lockfile_age_days": 0
+    "lockfile_age_days": 7
   },
   "ci_health": {
     "pass_rate_30d": 0.0,


### PR DESCRIPTION
Quiet week: zero commits in the last 7 days. No git activity to diff against, so delta sections are skipped. Current-state concerns and the recommended action are surfaced below from the fresh sense report.

## Current state concerns

- CI pass rate 30d sits at 0.0% with an empty last-10-runs list. The number reads alarming but reflects zero observed runs rather than a sweep of failures. Verify the CI collector is wired to the right workflow before treating this as a real regression.
- JS dependency vulnerabilities: 1 (up from 0 at the 2026-06-08 baseline). Identify and patch via `npm audit`.
- Files over 300 lines: 211 vs baseline 158 (+33.5%, well past the +10% threshold). Largest contributor is new growth in `mcp-server/`.
- Largest files over 2000 lines: `mcp-server/test/providers.test.ts` (3334), `app/docs/page.tsx` (3265), `sdk/legacy/dashclaw-v1.js` (2960), `mcp-server/src/provider-actions.ts` (2793). The test file is now the single biggest file in the repo.

## One thing to do this week

Run `npm audit` to identify the single JS vulnerability that appeared since 2026-06-08, then `npm audit fix` (or a manual bump on the offending package). One vulnerability with a 7-day-old lockfile is the cheapest item to clear and prevents the count from compounding next week. Budget: under 1 hour including verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiKJC8KXr1LXjoeTxnQEJG)_