### PR TITLE
Weekly health digest for 2026-07-06

### DIFF
--- a/.organism/digests/2026-07-06.md
+++ b/.organism/digests/2026-07-06.md
@@ -1,0 +1,42 @@
+# Weekly Health Digest for 2026-07-06
+
+**Coverage:** This week vs 2026-06-08.
+
+## What got worse
+
+- Files over 300 lines: 233 vs 158 (+75). Nearly a 50% jump after a heavy release wave (v4.59 through v4.73 landed in the window).
+- Three files crossed 2000 lines: middleware.js (1615 to 2101), sdk/dashclaw.js (1539 to 2132), and app/lib/repositories/actions.repository.ts (1366 to 2153). All sit on the hot path.
+- Python files over 300 lines: 45 vs 30. Growth in the hooks and livingcode tree without matching decomposition.
+
+## What got better
+
+- Test-file ratio: 0.394 vs 0.361. Modest but real coverage-density improvement.
+- JS dependencies outdated: 28 vs 31, alongside total deps dropping 51 to 48.
+- Files changed in 7 days: 177 vs 214. Less churn despite the same commit count.
+
+## New untested routes
+
+None.
+
+## Current state concerns
+
+- Files over 300 lines: 233 vs baseline+10% of 174. Well over the guardrail.
+- Seven largest_files entries exceed 2000 lines: app/docs/page.tsx (3559), mcp-server/test/providers.test.ts (3334), sdk/legacy/dashclaw-v1.js (2970), mcp-server/src/provider-actions.ts (2793), actions.repository.ts (2153), sdk/dashclaw.js (2132), middleware.js (2101).
+- CI pass_rate_30d reads 0.0% but gate_count is 0 and last_10_runs is empty. Collector data gap, not real failure. Worth checking the ci_health collector.
+
+## One thing to do this week
+
+Decompose middleware.js. It grew 486 lines to 2101 and gates every authenticated request. Splitting the auth-lookup path and schema-init branch into named helpers behind an unchanged facade is a bounded 3-hour job with coverage in the existing route contract tests.
+
+## Raw deltas
+
+| Metric | This week | Last week | Delta |
+|---|---|---|---|
+| CI pass rate 30d | 0.0% | 0.0% | 0 |
+| Last 10 CI runs | (none) | (none) | 0 |
+| Files over 300 lines | 233 | 158 | +75 |
+| Untested routes | 0 | 0 | 0 |
+| JS vulnerabilities | 0 | 0 | 0 |
+| Lockfile age (days) | 0 | 0 | 0 |
+| Commits (7d) | 50 | 50 | 0 |
+| TODO count | 0 | 0 | 0 |

--- a/.organism/digests/last-week-state.json
+++ b/.organism/digests/last-week-state.json
@@ -1,6 +1,6 @@
 {
   "organism": "dashclaw",
-  "timestamp": "2026-06-08T13:10:01.181116+00:00",
+  "timestamp": "2026-07-06T13:01:22.956617+00:00",
   "collector_status": {
     "git_stats": "ok",
     "test_health": "ok",
@@ -20,7 +20,7 @@
         "commits": 50
       }
     ],
-    "files_changed_7d": 214
+    "files_changed_7d": 177
   },
   "test_health": {
     "js_tests": {
@@ -33,61 +33,61 @@
       "passed": 0,
       "failed": 0
     },
-    "test_file_ratio": 0.36131687242798355,
+    "test_file_ratio": 0.3942307692307692,
     "untested_routes": []
   },
   "code_quality": {
-    "files_over_300_lines": 158,
+    "files_over_300_lines": 233,
     "largest_files": [
       {
         "path": "app/docs/page.tsx",
-        "lines": 3066
+        "lines": 3559
+      },
+      {
+        "path": "mcp-server/test/providers.test.ts",
+        "lines": 3334
       },
       {
         "path": "sdk/legacy/dashclaw-v1.js",
-        "lines": 2960
+        "lines": 2970
       },
       {
-        "path": "middleware.js",
-        "lines": 1615
-      },
-      {
-        "path": "sdk/dashclaw.js",
-        "lines": 1539
-      },
-      {
-        "path": "schema/schema.js",
-        "lines": 1438
+        "path": "mcp-server/src/provider-actions.ts",
+        "lines": 2793
       },
       {
         "path": "app/lib/repositories/actions.repository.ts",
-        "lines": 1366
+        "lines": 2153
       },
       {
-        "path": "app/decisions/[actionId]/page.tsx",
-        "lines": 1271
+        "path": "sdk/dashclaw.js",
+        "lines": 2132
       },
       {
-        "path": "app/lib/demo/demoMiddleware.ts",
-        "lines": 1181
+        "path": "middleware.js",
+        "lines": 2101
       },
       {
-        "path": "cli/bin/dashclaw.js",
-        "lines": 1163
+        "path": "mcp-server/src/tools/index.ts",
+        "lines": 1996
       },
       {
-        "path": "packages/openclaw-plugin/src/index.ts",
-        "lines": 1115
+        "path": "schema/schema.js",
+        "lines": 1933
+      },
+      {
+        "path": "mcp-server/lib/provider-actions.js",
+        "lines": 1825
       }
     ],
     "eslint_status": "fail",
-    "python_files_over_300": 30,
+    "python_files_over_300": 45,
     "todo_count": 0,
     "archive_size_kb": 151
   },
   "dependency_health": {
-    "js_dependencies": 51,
-    "js_outdated": 31,
+    "js_dependencies": 48,
+    "js_outdated": 28,
     "js_vulnerabilities": 0,
     "python_dependencies": 0,
     "lockfile_age_days": 0


### PR DESCRIPTION
## What got worse

- Files over 300 lines: 233 vs 158 (+75). Nearly a 50% jump after a heavy release wave (v4.59 through v4.73 landed in the window).
- Three files crossed 2000 lines: middleware.js (1615 to 2101), sdk/dashclaw.js (1539 to 2132), and app/lib/repositories/actions.repository.ts (1366 to 2153). All sit on the hot path.
- Python files over 300 lines: 45 vs 30. Growth in the hooks and livingcode tree without matching decomposition.

## What got better

- Test-file ratio: 0.394 vs 0.361. Modest but real coverage-density improvement.
- JS dependencies outdated: 28 vs 31, alongside total deps dropping 51 to 48.
- Files changed in 7 days: 177 vs 214. Less churn despite the same commit count.

## New untested routes

None.

## Current state concerns

- Files over 300 lines: 233 vs baseline+10% of 174. Well over the guardrail.
- Seven largest_files entries exceed 2000 lines: app/docs/page.tsx (3559), mcp-server/test/providers.test.ts (3334), sdk/legacy/dashclaw-v1.js (2970), mcp-server/src/provider-actions.ts (2793), actions.repository.ts (2153), sdk/dashclaw.js (2132), middleware.js (2101).
- CI pass_rate_30d reads 0.0% but gate_count is 0 and last_10_runs is empty. Collector data gap, not real failure. Worth checking the ci_health collector.

## One thing to do this week

Decompose middleware.js. It grew 486 lines to 2101 and gates every authenticated request. Splitting the auth-lookup path and schema-init branch into named helpers behind an unchanged facade is a bounded 3-hour job with coverage in the existing route contract tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_019SAYE2wEhSS9uf9zHsyb5i)_