### PR TITLE
fix: bound Redis rate-limit connection timeout

### DIFF
--- a/__tests__/unit/org-rate-limit.test.js
+++ b/__tests__/unit/org-rate-limit.test.js
@@ -6,6 +6,7 @@ const { mockRedisClient, mockCreateClient } = vi.hoisted(() => {
     on: vi.fn(),
     incr: vi.fn(async () => 1),
     pExpire: vi.fn(async () => true),
+    disconnect: vi.fn(async () => {}),
   };
   return { mockRedisClient, mockCreateClient: vi.fn(() => mockRedisClient) };
 });
@@ -100,6 +101,34 @@ describe('checkOrgRateLimit', () => {
       }
       const blocked = await checkOrgRateLimit('org_a');
       expect(blocked.allowed).toBe(false);
+    });
+
+    it('falls back to the memory limiter when Redis connect never settles (bounded, no hang)', async () => {
+      // Reproduces the production hang: a stalled/unreachable endpoint where
+      // client.connect() never resolves or rejects. The governance path must
+      // still return within a bounded amount of (virtual) time, degraded to
+      // the in-memory backend rather than pending until the 30s client timeout.
+      mockRedisClient.connect.mockImplementationOnce(() => new Promise(() => {}));
+
+      const backend = await Promise.race([
+        checkOrgRateLimit('org_a').then((r) => r.backend),
+        // Drain the entire client-timeout window of virtual time. If connect
+        // was left unbounded, checkOrgRateLimit is still pending here and this
+        // sentinel wins — a clean, fast failure instead of a real 30s hang.
+        vi.advanceTimersByTimeAsync(30000).then(() => 'PENDING'),
+      ]);
+
+      expect(backend).toBe('memory');
+    });
+
+    it('destroys the timed-out client so a stalled socket cannot leak', async () => {
+      mockRedisClient.connect.mockImplementationOnce(() => new Promise(() => {}));
+
+      const promise = checkOrgRateLimit('org_a');
+      await vi.advanceTimersByTimeAsync(30000);
+      await promise;
+
+      expect(mockRedisClient.disconnect).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/lib/org-rate-limit.ts
+++ b/app/lib/org-rate-limit.ts
@@ -28,8 +28,17 @@ type RedisLike = {
   pExpire: (key: string, ms: number) => Promise<unknown>;
 };
 
+type CleanableClient = {
+  destroy?: () => void;
+  disconnect?: () => Promise<unknown>;
+};
+
 const MEMORY_MAX_ENTRIES = 10000;
 const REDIS_RETRY_COOLDOWN_MS = 30000;
+// Bound the node-redis connect(): a cold serverless instance pointed at a
+// stalled or unreachable endpoint could otherwise hang the whole governance
+// path until the client's 30s timeout. Fail over to memory well before that.
+const REDIS_CONNECT_TIMEOUT_MS = 3000;
 
 let memoryCounters = new Map<string, MemoryEntry>();
 let redisClientPromise: Promise<RedisLike | null> | null = null;
@@ -51,6 +60,21 @@ function redisUrl(): string {
   return process.env.REDIS_URL || process.env.REALTIME_REDIS_URL || '';
 }
 
+// Forcibly release a client whose connect() failed or timed out so a half-open
+// socket can't leak across cold starts. Best-effort: never throws, never blocks
+// the fallback (node-redis v4 exposes disconnect(); v5 adds destroy()).
+function safeDisconnect(client: CleanableClient): void {
+  try {
+    if (typeof client.destroy === 'function') {
+      client.destroy();
+    } else if (typeof client.disconnect === 'function') {
+      void Promise.resolve(client.disconnect()).catch(() => {});
+    }
+  } catch {
+    // teardown is best-effort
+  }
+}
+
 async function getRedisClient(): Promise<RedisLike | null> {
   const url = redisUrl();
   if (!url) return null;
@@ -58,10 +82,33 @@ async function getRedisClient(): Promise<RedisLike | null> {
   if (!redisClientPromise) {
     redisClientPromise = (async () => {
       const mod = await import('redis');
-      const client = mod.createClient({ url });
+      const client = mod.createClient({
+        url,
+        // First line of defense: let node-redis abort the TCP connect itself.
+        socket: { connectTimeout: REDIS_CONNECT_TIMEOUT_MS },
+      });
       // Without an error listener node-redis throws unhandled on disconnects.
       client.on('error', () => {});
-      await client.connect();
+      // Second line of defense: race connect() against our own timer so this
+      // never stays pending even if the client ignores connectTimeout (the
+      // observed production hang). Clean up the client on either failure path.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          client.connect(),
+          new Promise<never>((_resolve, reject) => {
+            timer = setTimeout(
+              () => reject(new Error(`Redis connect exceeded ${REDIS_CONNECT_TIMEOUT_MS}ms`)),
+              REDIS_CONNECT_TIMEOUT_MS,
+            );
+          }),
+        ]);
+      } catch (err) {
+        safeDisconnect(client as unknown as CleanableClient);
+        throw err;
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
       return client as unknown as RedisLike;
     })().catch((err) => {
       console.warn('[org-rate-limit] Redis connect failed, using memory fallback:', err?.message || err);


### PR DESCRIPTION
## Summary
- bound Redis rate-limiter cold connects to 3 seconds
- fall back to the existing in-memory org limiter if Redis stalls
- clean up the timed-out client to avoid leaked sockets
- add regression coverage for never-settling connects

## Production symptom
Authenticated POST `/api/guard` and POST `/api/actions` intermittently hung until OpenClaw's 30-second fail-closed timeout, while authenticated reads remained healthy. Both write routes share `checkOrgRateLimit`; its cold `client.connect()` had no application-level bound.

## Verification
- focused org-rate-limit tests: 12/12
- related guard/action tests: 23/23
- TypeScript: clean
- ESLint on changed files: clean
- production build: successful