### PR TITLE
fix: bound Redis rate-limit commands and drop stalled clients

### DIFF
--- a/__tests__/unit/org-rate-limit.test.js
+++ b/__tests__/unit/org-rate-limit.test.js
@@ -130,6 +130,43 @@ describe('checkOrgRateLimit', () => {
 
       expect(mockRedisClient.disconnect).toHaveBeenCalledTimes(1);
     });
+
+    it('falls back to the memory limiter when a Redis command never settles (bounded, no hang)', async () => {
+      // The connect-time hang was fixed in #222; this is the same failure mode
+      // one layer later: connect() succeeded on a warm instance, then the
+      // socket went half-open (serverless NAT idle-drop — no FIN, no error
+      // event, no reconnect) and INCR never settles. The governance path must
+      // still return within bounded time, degraded to memory.
+      mockRedisClient.incr.mockImplementationOnce(() => new Promise(() => {}));
+
+      const backend = await Promise.race([
+        checkOrgRateLimit('org_a').then((r) => r.backend),
+        vi.advanceTimersByTimeAsync(30000).then(() => 'PENDING'),
+      ]);
+
+      expect(backend).toBe('memory');
+    });
+
+    it('discards the stalled client after a command timeout so the cooldown retry reconnects', async () => {
+      mockRedisClient.incr.mockImplementationOnce(() => new Promise(() => {}));
+
+      const first = await Promise.race([
+        checkOrgRateLimit('org_a'),
+        vi.advanceTimersByTimeAsync(30000).then(() => null),
+      ]);
+      expect(first?.backend).toBe('memory');
+      // The half-open client is torn down, not left cached: without this, the
+      // post-cooldown retry reuses the dead socket and hangs on every window.
+      expect(mockRedisClient.disconnect).toHaveBeenCalledTimes(1);
+
+      // Past the 30s retry cooldown a NEW client must be created and Redis
+      // resumes as the backend.
+      await vi.advanceTimersByTimeAsync(31000);
+      mockRedisClient.incr.mockResolvedValue(1);
+      const recovered = await checkOrgRateLimit('org_a');
+      expect(recovered.backend).toBe('redis');
+      expect(mockCreateClient).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('disable escape hatch', () => {

--- a/app/lib/org-rate-limit.ts
+++ b/app/lib/org-rate-limit.ts
@@ -39,6 +39,25 @@ const REDIS_RETRY_COOLDOWN_MS = 30000;
 // stalled or unreachable endpoint could otherwise hang the whole governance
 // path until the client's 30s timeout. Fail over to memory well before that.
 const REDIS_CONNECT_TIMEOUT_MS = 3000;
+// Bound the commands too: a warm instance can hold a half-open socket (NAT
+// idle-drop emits no error, so node-redis never reconnects) and INCR would
+// then pend forever — the connect-time hang one layer later.
+const REDIS_COMMAND_TIMEOUT_MS = 2000;
+
+class RedisCommandTimeout extends Error {}
+
+/** Race a Redis command against a timer so it can never pend unbounded. */
+function withCommandTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    promise,
+    new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => reject(new RedisCommandTimeout(`Redis command exceeded ${ms}ms`)), ms);
+    }),
+  ]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
 
 let memoryCounters = new Map<string, MemoryEntry>();
 let redisClientPromise: Promise<RedisLike | null> | null = null;
@@ -176,15 +195,22 @@ export async function checkOrgRateLimit(orgId: string): Promise<OrgRateLimitResu
   const client = await getRedisClient();
   if (client) {
     try {
-      const count = await client.incr(key);
+      const count = await withCommandTimeout(client.incr(key), REDIS_COMMAND_TIMEOUT_MS);
       if (count === 1) {
         // Grace second so the key outlives its window even under clock skew.
-        await client.pExpire(key, windowMs + 1000);
+        await withCommandTimeout(client.pExpire(key, windowMs + 1000), REDIS_COMMAND_TIMEOUT_MS);
       }
       return buildResult(count, limit, msUntilReset, 'redis');
     } catch (err) {
       console.warn('[org-rate-limit] Redis check failed, using memory fallback:', (err as Error)?.message || err);
       redisFailedAt = now;
+      if (err instanceof RedisCommandTimeout) {
+        // A timed-out command means the cached client's socket is likely
+        // half-open; drop it so the post-cooldown retry builds a fresh
+        // connection instead of reusing the dead one every window.
+        safeDisconnect(client as unknown as CleanableClient);
+        redisClientPromise = null;
+      }
     }
   }
 


### PR DESCRIPTION
Follow-up to #222. That PR bounded `client.connect()`; this bounds the layer after it.

**Remaining defect (reproduced with a failing test before the fix):** on a warm instance whose pooled Redis socket has gone half-open (serverless NAT idle-drop — no FIN, no `error` event, so node-redis never reconnects), `client.incr()` / `client.pExpire()` pend forever. `checkOrgRateLimit` then holds `POST /api/guard` and `POST /api/actions` until the OpenClaw client's 30s watchdog — the same incident shape as the connect-time hang, one layer later. The stale client also stayed cached, so every post-cooldown window would reuse the dead socket.

**Fix (app/lib/org-rate-limit.ts):**
- `withCommandTimeout`: race each Redis command against a 2s timer (`REDIS_COMMAND_TIMEOUT_MS`), timer always cleared.
- On command timeout: `safeDisconnect` the client and clear `redisClientPromise` so the post-cooldown retry connects fresh; fall back to the bounded in-memory limiter — never unlimited.
- Plain command errors keep the existing cooldown-only behavior (node-redis reconnects itself on real socket errors).

**Tests (__tests__/unit/org-rate-limit.test.js):** never-settling INCR returns bounded, degraded to `memory`, within 30s of virtual time; stalled client is disconnected exactly once and a NEW client is created after the 30s cooldown. Both observed failing against 6106f10a before the fix.

**Verification:** targeted 14/14; full suite 4682 passed with 4 failures confined to known worktree-CRLF-sensitive files (all pass in a normal checkout); `tsc --noEmit` clean; eslint clean; `next build` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBgw349bUqQCmFWibKDZK2