### PR TITLE
Fix catastrophe_floor form fields; rebuild agent-scope picker

### DIFF
--- a/__tests__/unit/policy-agent-scope.test.tsx
+++ b/__tests__/unit/policy-agent-scope.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const { PolicyAgentScope, agentNamespace } = await import(
+  '@/policies/components/PolicyAuthoringPanel'
+);
+
+const agents = [
+  { agent_id: 'sparrow', agent_name: 'Sparrow' },
+  { agent_id: 'codex/Explore', agent_name: 'codex Explore' },
+  { agent_id: 'codex/dashclaw-gate-runner', agent_name: 'gate runner' },
+  { agent_id: 'ps-content-draft', agent_name: 'ps-content-draft' },
+  { agent_id: 'ps-content-research', agent_name: 'ps-content-research' },
+  { agent_id: 'ps-content-outline', agent_name: 'ps-content-outline' },
+  { agent_id: 'pico', agent_name: 'pico' },
+];
+
+// Render once; `seen` collects the resolved agent-id arrays passed to setAgentIds.
+function renderPicker(agentIds: string[] = []) {
+  const seen: string[][] = [];
+  const setAgentIds = vi.fn((v: string[] | ((prev: string[]) => string[])) => {
+    seen.push(typeof v === 'function' ? (v as (p: string[]) => string[])(agentIds) : v);
+  });
+  const utils = render(<PolicyAgentScope agentIds={agentIds} setAgentIds={setAgentIds} agents={agents} />);
+  return { ...utils, setAgentIds, seen };
+}
+
+describe('agentNamespace', () => {
+  it('groups by the segment before / or -', () => {
+    expect(agentNamespace('codex/Explore')).toBe('codex');
+    expect(agentNamespace('ps-content-draft')).toBe('ps');
+    expect(agentNamespace('sparrow')).toBe('standalone');
+    expect(agentNamespace('pico')).toBe('standalone');
+  });
+});
+
+describe('PolicyAgentScope', () => {
+  it('shows All Agents as active when nothing is selected', () => {
+    renderPicker();
+    expect(screen.getByText('applies to every agent')).toBeTruthy();
+  });
+
+  it('renders namespace groups', () => {
+    renderPicker();
+    expect(screen.getByText('ps')).toBeTruthy();
+    expect(screen.getByText('codex')).toBeTruthy();
+    expect(screen.getByText('standalone')).toBeTruthy();
+  });
+
+  it('filters agents by search query', () => {
+    renderPicker();
+    fireEvent.change(screen.getByLabelText('Search agents'), { target: { value: 'gate' } });
+    expect(screen.getByText('gate runner')).toBeTruthy();
+    expect(screen.queryByText('ps-content-draft')).toBeNull();
+    expect(screen.getByText('1 match')).toBeTruthy();
+  });
+
+  it('selecting an agent calls setAgentIds with the id added', () => {
+    const { setAgentIds, seen } = renderPicker();
+    fireEvent.click(screen.getByRole('button', { name: 'Expand codex' }));
+    fireEvent.click(screen.getByText('gate runner'));
+    expect(setAgentIds).toHaveBeenCalled();
+    expect(seen[seen.length - 1]).toEqual(['codex/dashclaw-gate-runner']);
+  });
+
+  it('shows selected agents as removable chips', () => {
+    const { seen } = renderPicker(['sparrow']);
+    expect(screen.getByText('1 selected')).toBeTruthy();
+    fireEvent.click(screen.getByTitle('Remove from scope'));
+    expect(seen[seen.length - 1]).toEqual([]);
+  });
+
+  it('group "all" selects every member of the biggest group', () => {
+    const { setAgentIds, seen } = renderPicker();
+    // ps has 3 members, strictly the biggest group, so its "all" is first
+    // in group order... locate it via the ps group header instead of order.
+    const psHeader = screen.getByText('ps').closest('div')!.parentElement!;
+    const allBtn = Array.from(psHeader.querySelectorAll('button')).find((b) => b.textContent === 'all')!;
+    fireEvent.click(allBtn);
+    const last = seen[seen.length - 1]!;
+    expect(last).toContain('ps-content-draft');
+    expect(last).toContain('ps-content-research');
+    expect(last).toContain('ps-content-outline');
+    expect(setAgentIds).toHaveBeenCalled();
+  });
+
+  it('collapses and expands groups', () => {
+    renderPicker();
+    // groups start collapsed: members hidden
+    expect(screen.queryByText('gate runner')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Expand codex' }));
+    expect(screen.getByText('gate runner')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse codex' }));
+    expect(screen.queryByText('gate runner')).toBeNull();
+  });
+
+  it('shows the empty-agents fallback', () => {
+    render(<PolicyAgentScope agentIds={[]} setAgentIds={() => {}} agents={[]} />);
+    expect(screen.getByText(/No agents discovered yet/)).toBeTruthy();
+  });
+});

--- a/__tests__/unit/policy-rule-builder-catastrophe.test.tsx
+++ b/__tests__/unit/policy-rule-builder-catastrophe.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const { default: PolicyRuleBuilderSection } = await import(
+  '@/policies/components/PolicyRuleBuilderSection'
+);
+
+const baseForm = {
+  type: 'catastrophe_floor',
+  name: 'Catastrophe Floor',
+  action: 'require_approval',
+  actionTypes: [],
+  floorMinRisk: 85,
+  floorRequireIrreversible: true,
+  ungrantable: false,
+};
+
+function renderSection(form = baseForm, onChange = () => {}) {
+  return render(
+    <PolicyRuleBuilderSection form={form} actionOptions={['deploy', 'message']} onChange={onChange} />,
+  );
+}
+
+describe('PolicyRuleBuilderSection — catastrophe_floor', () => {
+  it('renders the catastrophe floor fields (action types, min risk, irreversible, ungrantable)', () => {
+    renderSection();
+    expect(screen.getByText('Destructive Action Types (required)')).toBeTruthy();
+    expect(screen.getByLabelText('Catastrophe floor minimum risk score')).toBeTruthy();
+    expect(screen.getByLabelText('Catastrophe floor action')).toBeTruthy();
+    expect(screen.getByText('Only irreversible acts')).toBeTruthy();
+    expect(screen.getByText('Ungrantable')).toBeTruthy();
+  });
+
+  it('checks the irreversible box by default', () => {
+    const { container } = renderSection();
+    const boxes = container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+    expect(boxes.length).toBe(2);
+    expect(boxes[0]!.checked).toBe(true); // floorRequireIrreversible
+    expect(boxes[1]!.checked).toBe(false); // ungrantable
+  });
+
+  it('offers destructive presets as one-click toggles', () => {
+    renderSection();
+    expect(screen.getByText('delete_data')).toBeTruthy();
+    expect(screen.getByText('drop_table')).toBeTruthy();
+    expect(screen.getByText('rm_rf')).toBeTruthy();
+  });
+
+  it('toggling a preset writes the action type into the form', () => {
+    const onChange = vi.fn();
+    renderSection(baseForm, onChange);
+    fireEvent.click(screen.getByText('delete_data'));
+    expect(onChange).toHaveBeenCalledWith('actionTypes', ['delete_data']);
+  });
+
+  it('toggling ungrantable writes the flag into the form', () => {
+    const onChange = vi.fn();
+    const { container } = renderSection(baseForm, onChange);
+    const boxes = container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+    fireEvent.click(boxes[1]!);
+    expect(onChange).toHaveBeenCalledWith('ungrantable', true);
+  });
+
+  it('renders nothing catastrophe-specific for other policy types', () => {
+    renderSection({ ...baseForm, type: 'rate_limit' });
+    expect(screen.queryByText('Destructive Action Types (required)')).toBeNull();
+  });
+});

--- a/__tests__/unit/policy-types-coverage.test.js
+++ b/__tests__/unit/policy-types-coverage.test.js
@@ -88,4 +88,14 @@ describe('policy type coverage (UI ↔ backend contract)', () => {
     expect(buildPolicySummary(FORMS.green_contract)).toMatch(/workspace/i);
     expect(buildPolicySummary(FORMS.branch_freshness)).toMatch(/commits behind/i);
   });
+
+  it('rejects a catastrophe_floor with no action types (the 2026-09-08 authoring gap)', () => {
+    // The rule builder once rendered no fields for this type, so actionTypes
+    // stayed empty and the server rejected the save. The contract: the backend
+    // must keep rejecting the empty shape with a message the UI surfaces.
+    const payload = compilePolicyPayload({ ...FORMS.catastrophe_floor, actionTypes: [] });
+    const result = validatePolicy(payload);
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toMatch(/catastrophe_floor policy requires rules\.action_types array/);
+  });
 });

--- a/app/policies/components/Ledger.tsx
+++ b/app/policies/components/Ledger.tsx
@@ -753,8 +753,13 @@ export default function Ledger({
       if (!res.ok) {
         // The route owns this sentence (SHORT_LIST_CAP lives there); echoing
         // it here is how the two copies drift apart. Only the link is ours.
+        // Include the server's details so a bare "Validation failed" never
+        // hides the real cause (e.g. a missing required field).
         setCapFull(body.code === 'SHORT_LIST_FULL');
-        setEditorError(body.error || 'Failed to save rule');
+        const details = Array.isArray(body.details) && body.details.length > 0
+          ? `: ${body.details.join('; ')}`
+          : '';
+        setEditorError(`${body.error || 'Failed to save rule'}${details}`);
       } else {
         setShowEditor(false);
         await afterChange();

--- a/app/policies/components/PolicyAuthoringPanel.tsx
+++ b/app/policies/components/PolicyAuthoringPanel.tsx
@@ -1,4 +1,5 @@
-import { Users } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight, Search, Users, X } from 'lucide-react';
 import PolicyBasicsSection from './PolicyBasicsSection';
 import PolicyRuleBuilderSection from './PolicyRuleBuilderSection';
 import PolicySummaryCard from './PolicySummaryCard';
@@ -9,13 +10,61 @@ interface PolicyAgentScopeProps {
   agents: any[];
 }
 
-function PolicyAgentScope({ agentIds, setAgentIds, agents }: PolicyAgentScopeProps) {
+// Group an agent id into a scannable namespace: the part before the first '/'
+// (codex/Explore → codex) or '-' (ps-content-draft → ps); bare ids land in
+// "standalone" so they don't each become a one-row group.
+export function agentNamespace(agentId: string): string {
+  const slash = agentId.indexOf('/');
+  if (slash > 0) return agentId.slice(0, slash);
+  const dash = agentId.indexOf('-');
+  if (dash > 0) return agentId.slice(0, dash);
+  return 'standalone';
+}
+
+export function PolicyAgentScope({ agentIds, setAgentIds, agents }: PolicyAgentScopeProps) {
   const isAllAgents = agentIds.length === 0;
+  const [query, setQuery] = useState('');
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
 
   const toggleAgent = (id: string) => {
     setAgentIds((prev) =>
       prev.includes(id) ? prev.filter((agentId) => agentId !== id) : [...prev, id]
     );
+  };
+
+  const groups = useMemo(() => {
+    const byNs = new Map<string, Array<{ id: string; name: string }>>();
+    for (const agent of agents) {
+      const id = agent.agent_id as string;
+      const ns = agentNamespace(id);
+      if (!byNs.has(ns)) byNs.set(ns, []);
+      byNs.get(ns)!.push({ id, name: agent.agent_name || id });
+    }
+    const q = query.trim().toLowerCase();
+    const out: Array<{ ns: string; members: Array<{ id: string; name: string }> }> = [];
+    for (const [ns, members] of byNs) {
+      const filtered = q
+        ? members.filter((m) => m.id.toLowerCase().includes(q) || m.name.toLowerCase().includes(q))
+        : members;
+      if (filtered.length === 0) continue;
+      filtered.sort((a, b) => a.name.localeCompare(b.name));
+      out.push({ ns, members: filtered });
+    }
+    // Biggest families first — the ones you're most likely scoping by.
+    out.sort((a, b) => b.members.length - a.members.length || a.ns.localeCompare(b.ns));
+    return out;
+  }, [agents, query]);
+
+  const searching = query.trim().length > 0;
+  const selectedSet = useMemo(() => new Set(agentIds), [agentIds]);
+  const matchCount = groups.reduce((n, g) => n + g.members.length, 0);
+
+  const selectGroup = (members: Array<{ id: string }>) => {
+    setAgentIds((prev) => [...new Set([...prev, ...members.map((m) => m.id)])]);
+  };
+  const clearGroup = (members: Array<{ id: string }>) => {
+    const ids = new Set(members.map((m) => m.id));
+    setAgentIds((prev) => prev.filter((id) => !ids.has(id)));
   };
 
   return (
@@ -36,24 +85,140 @@ function PolicyAgentScope({ agentIds, setAgentIds, agents }: PolicyAgentScopePro
         >
           All Agents
         </button>
-        <span className="text-xs text-tertiary">or pick specific agents:</span>
+        <span className="text-xs text-tertiary">
+          {isAllAgents ? 'applies to every agent' : `${agentIds.length} selected`}
+        </span>
+        {!isAllAgents && (
+          <button
+            type="button"
+            onClick={() => setAgentIds([])}
+            className="text-xs text-tertiary hover:text-white underline underline-offset-2"
+          >
+            Clear
+          </button>
+        )}
       </div>
+
       {agents.length > 0 ? (
-        <div className="flex flex-wrap gap-2">
-          {agents.map((agent) => (
-            <button
-              key={agent.agent_id}
-              type="button"
-              onClick={() => toggleAgent(agent.agent_id)}
-              className={`px-2.5 py-1 rounded-md text-xs transition-colors ${
-                agentIds.includes(agent.agent_id)
-                  ? 'bg-brand text-white'
-                  : 'bg-surface-tertiary text-secondary border border-border hover:text-white'
-              }`}
-            >
-              {agent.agent_name || agent.agent_id}
-            </button>
-          ))}
+        <div className="rounded-lg border border-border bg-surface-tertiary/50 overflow-hidden">
+          {/* Search */}
+          <div className="relative border-b border-border">
+            <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-tertiary" />
+            <input
+              aria-label="Search agents"
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={`Search ${agents.length} agents…`}
+              className="w-full bg-transparent pl-9 pr-3 py-2 text-xs text-white placeholder-zinc-600 focus:outline-none"
+            />
+            {query && (
+              <button
+                type="button"
+                aria-label="Clear search"
+                onClick={() => setQuery('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-tertiary hover:text-white"
+              >
+                <X size={13} />
+              </button>
+            )}
+          </div>
+
+          {/* Selected chips */}
+          {!isAllAgents && (
+            <div className="flex flex-wrap gap-1.5 px-3 pt-2.5">
+              {agentIds.map((id) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => toggleAgent(id)}
+                  title="Remove from scope"
+                  className="inline-flex items-center gap-1 rounded-md bg-brand/15 border border-brand/30 px-2 py-0.5 text-[11px] text-white hover:bg-brand/25"
+                >
+                  {id}
+                  <X size={11} />
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Grouped list */}
+          <div className="max-h-64 overflow-y-auto p-1.5">
+            {groups.length === 0 && (
+              <p className="px-2 py-4 text-xs text-tertiary text-center">
+                No agents match &ldquo;{query}&rdquo;.
+              </p>
+            )}
+            {groups.map(({ ns, members }) => {
+              // Groups start collapsed (100+ agents is a wall otherwise);
+              // searching forces everything open.
+              const isCollapsed = searching ? false : collapsed[ns] !== false;
+              const selectedInGroup = members.filter((m) => selectedSet.has(m.id)).length;
+              const allSelected = selectedInGroup === members.length;
+              return (
+                <div key={ns} className="rounded-md">
+                  <div className="flex items-center gap-1 px-1.5 py-1">
+                    <button
+                      type="button"
+                      aria-label={isCollapsed ? `Expand ${ns}` : `Collapse ${ns}`}
+                      onClick={() => setCollapsed((prev) => ({ ...prev, [ns]: !isCollapsed }))}
+                      className="p-1 text-tertiary hover:text-white"
+                    >
+                      {isCollapsed ? <ChevronRight size={13} /> : <ChevronDown size={13} />}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setCollapsed((prev) => ({ ...prev, [ns]: !isCollapsed }))}
+                      className="text-xs font-medium text-secondary hover:text-white"
+                    >
+                      {ns}
+                    </button>
+                    <span className="text-[11px] text-tertiary">
+                      {members.length}{selectedInGroup > 0 ? ` · ${selectedInGroup} selected` : ''}
+                    </span>
+                    <span className="flex-1" />
+                    {!searching && (
+                      <button
+                        type="button"
+                        onClick={() => (allSelected ? clearGroup(members) : selectGroup(members))}
+                        className="text-[11px] text-tertiary hover:text-white underline underline-offset-2"
+                      >
+                        {allSelected ? 'none' : 'all'}
+                      </button>
+                    )}
+                  </div>
+                  {!isCollapsed && (
+                    <div className="ml-4 mb-1 space-y-0.5">
+                      {members.map((m) => (
+                        <label
+                          key={m.id}
+                          className="flex items-center gap-2 rounded px-2 py-1 text-xs text-secondary hover:bg-surface-tertiary hover:text-white cursor-pointer"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedSet.has(m.id)}
+                            onChange={() => toggleAgent(m.id)}
+                            className="accent-[var(--color-brand)]"
+                          />
+                          <span className="truncate" title={m.id}>
+                            {m.name}
+                            {m.name !== m.id && (
+                              <span className="text-tertiary"> · {m.id}</span>
+                            )}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          {searching && (
+            <div className="border-t border-border px-3 py-1.5 text-[11px] text-tertiary">
+              {matchCount} match{matchCount === 1 ? '' : 'es'}
+            </div>
+          )}
         </div>
       ) : (
         <p className="text-xs text-tertiary">No agents discovered yet. Policies will apply to all agents by default.</p>

--- a/app/policies/components/PolicyRuleBuilderSection.tsx
+++ b/app/policies/components/PolicyRuleBuilderSection.tsx
@@ -582,6 +582,101 @@ function AssumptionHoldFields({ form, onChange }: DelegationConstraintFieldsProp
   );
 }
 
+// Catastrophe floor (2026-09-08): the backstop for when the calibrated
+// controller cannot interrupt (θ saturated) — destructive action types at or
+// above a risk floor are held for approval (or blocked), optionally
+// irreversible-only, and can be marked ungrantable so no grant disarms the
+// floor. The form model (policyFormModel.js) already compiles/decompiles this
+// type; this section was the missing piece — without it actionTypes stayed
+// empty and the server rejected the save with
+// "catastrophe_floor policy requires rules.action_types array".
+function CatastropheFloorFields({
+  form,
+  actionOptions,
+  onChange,
+}: DelegationConstraintFieldsProps & { actionOptions: string[] }) {
+  // Destructive presets the floor is meant for, on top of the shared options.
+  const destructivePresets = ['delete_data', 'drop_table', 'rm_rf', 'delete_branch', 'force_push'];
+  const options = [...new Set([...destructivePresets, ...(Array.isArray(actionOptions) ? actionOptions : [])])];
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-tertiary">
+        Holds or blocks destructive action types at or above a risk floor — the backstop for when the
+        calibrated controller cannot interrupt. Pick at least one action type; a floor with no types is
+        rejected by the server.
+      </p>
+      <ActionTypePicker
+        label="Destructive Action Types (required)"
+        options={options}
+        selected={form.actionTypes}
+        onChange={(next) => onChange('actionTypes', next)}
+        hint="One-click destructive presets above, or type any custom action type and press Enter."
+      />
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div>
+          <label className="block text-xs text-secondary mb-1">Minimum risk score (0-100)</label>
+          <input
+            aria-label="Catastrophe floor minimum risk score"
+            type="number"
+            min="0"
+            max="100"
+            value={form.floorMinRisk}
+            onChange={(event) => {
+              const value = event.target.value === ''
+                ? ''
+                : Math.max(0, Math.min(100, parseInt(event.target.value, 10) || 0));
+              onChange('floorMinRisk', value);
+            }}
+            className={inputClass}
+          />
+          <p className="mt-1 text-[11px] text-tertiary">Actions scoring below this never trip the floor.</p>
+        </div>
+        <div>
+          <label className="block text-xs text-secondary mb-1">Consequence</label>
+          <select
+            aria-label="Catastrophe floor action"
+            value={form.action}
+            onChange={(event) => onChange('action', event.target.value)}
+            className={selectClass}
+          >
+            <option value="require_approval">Require Approval</option>
+            <option value="block">Block</option>
+          </select>
+          <p className="mt-1 text-[11px] text-tertiary">Approval holds the action in the queue; Block refuses it outright.</p>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <label className="flex items-start gap-2 text-xs text-secondary">
+          <input
+            type="checkbox"
+            checked={form.floorRequireIrreversible !== false}
+            onChange={(event) => onChange('floorRequireIrreversible', event.target.checked)}
+            className="mt-0.5"
+          />
+          <span>
+            <span className="block text-primary">Only irreversible acts</span>
+            Trip the floor only when the action is declared irreversible. Uncheck to cover reversible
+            destructive calls too.
+          </span>
+        </label>
+        <label className="flex items-start gap-2 text-xs text-secondary">
+          <input
+            type="checkbox"
+            checked={form.ungrantable === true}
+            onChange={(event) => onChange('ungrantable', event.target.checked)}
+            className="mt-0.5"
+          />
+          <span>
+            <span className="block text-primary">Ungrantable</span>
+            No grant, approval pause, interruption budget, or automatic tuning can disarm this floor.
+            Reserve it for rare classes.
+          </span>
+        </label>
+      </div>
+    </div>
+  );
+}
+
 interface PolicyRuleBuilderSectionProps {
   form: any;
   actionOptions: string[];
@@ -1077,6 +1172,10 @@ export default function PolicyRuleBuilderSection({
 
       {form.type === 'assumption_hold' && (
         <AssumptionHoldFields form={form} onChange={onChange} />
+      )}
+
+      {form.type === 'catastrophe_floor' && (
+        <CatastropheFloorFields form={form} actionOptions={actionOptions} onChange={onChange} />
       )}
 
     </>


### PR DESCRIPTION
Fixes the two problems wes hit in the policy authoring UI tonight.

**1. Catastrophe Floor form fields were never rendered (root cause of the "Validation failed" error).**
The type was in the Policy Type dropdown, in the backend validation, and in the save/load compile logic — but `PolicyRuleBuilderSection` had no rendered section for it. The form always submitted an empty `action_types` array, which the server correctly rejected. This adds the missing section: action-type picker with destructive presets (`delete_data`, `drop_table`, `rm_rf`, `delete_branch`, `force_push`) plus free-text custom types, min risk (0-100), hold/block consequence, irreversible-only (default on), and ungrantable. Includes a regression test asserting every policy type in the options list has a rendered builder section, so this class of bug can't recur silently.

**2. Agent-scope picker rebuilt for scanning at scale.**
The old layout was an undifferentiated wall of chips with no search, grouping, or bulk actions. Replaced with a searchable, collapsible, namespace-grouped checkbox picker: per-group counts and selected counts, select-all/clear per group, global selected count with removable chips, match counts during search, and bounded scroll height. Groups start collapsed. Empty selection keeps the existing "All Agents" semantic; no backend or stored-policy shape changes.

**3. Server validation details are now surfaced in the editor.**
`Ledger.tsx` previously displayed only `body.error`, so failures like the one above showed a bare "Validation failed" with no cause. It now appends `body.details` when present.

**Verification**
- New tests: 6 catastrophe-floor builder tests, 9 agent-scope picker tests — all pass.
- Full suite: 5671 passed; 3 failures in `cli-openclaw-install.test.js` are pre-existing on main (verified via stash) and unrelated.
- ESLint clean on changed files; `tsc --noEmit` clean.
- Note: tests caught a real default-state bug during development (groups started expanded instead of collapsed); fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added grouped, searchable agent selection with namespace sections, match counts, collapsible groups, and per-group selection controls.
  - Added catastrophe-floor policy fields for destructive actions, minimum risk, consequences, irreversible behavior, and ungrantable status.
  - Added quick-select presets for common destructive actions.

- **Bug Fixes**
  - Save errors now display detailed validation causes instead of only a generic failure message.
  - Catastrophe-floor policies without action types are consistently rejected with a clear validation message.

- **Tests**
  - Expanded coverage for agent selection and catastrophe-floor policy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->