### PR TITLE
Exclude scheduled self-test traffic from the approval flood budget

### DIFF
--- a/__tests__/unit/approval-flood.repository.test.js
+++ b/__tests__/unit/approval-flood.repository.test.js
@@ -43,6 +43,26 @@ describe('getRecentApprovalCountsByPolicy', () => {
       'org1', 15, true, SYNTHETIC_ACTION_TYPE_LIKE_PATTERNS, SYNTHETIC_AGENT_LIKE_PATTERNS,
     ]);
   });
+
+  it('excludes self-test traffic from flood counts (2026-09-09)', async () => {
+    const sql = mockSql([]);
+    await getRecentApprovalCountsByPolicy(sql, 'org1', 15);
+    const text = sql.query.mock.calls[0][0];
+    // Scheduled verification (catastrophe-floor probe) declares self_test:true
+    // in its guard payload; it is designed to trip policies and must never
+    // trip the flood budget. Excluded inside the unnest subquery, before
+    // aggregation — same as the synthetic predicate.
+    expect(text).toContain(`(context::jsonb ->> 'self_test') IS DISTINCT FROM 'true'`);
+  });
+
+  it('self-test exclusion is not lifted by includeSynthetic (2026-09-09)', async () => {
+    const sql = mockSql([]);
+    await getRecentApprovalCountsByPolicy(sql, 'org1', 15, { includeSynthetic: true });
+    const text = sql.query.mock.calls[0][0];
+    // The ?include_synthetic=1 escape hatch is for synthetic families; the
+    // self-test marker is a separate, always-on exclusion.
+    expect(text).toContain(`(context::jsonb ->> 'self_test') IS DISTINCT FROM 'true'`);
+  });
 });
 
 describe('getPolicyNamesByIds', () => {

--- a/app/lib/repositories/guardrails.repository.ts
+++ b/app/lib/repositories/guardrails.repository.ts
@@ -282,6 +282,12 @@ export async function getRecentApprovalCountsByPolicy(
            (action_type IS NULL OR action_type NOT LIKE ALL($4::text[]))
            AND (agent_id IS NULL OR agent_id NOT LIKE ALL($5::text[]))
          ))
+         -- Self-test exclusion (2026-09-09): scheduled verification traffic
+         -- (catastrophe-floor probe) declares self_test:true in its guard
+         -- payload and is DESIGNED to trip policies — it must never count
+         -- toward the flood budget. Always applied: the includeSynthetic
+         -- escape hatch is for synthetic families, not self-tests.
+         AND (context::jsonb ->> 'self_test') IS DISTINCT FROM 'true'
      ) sub
      GROUP BY sub.policy_id`,
     [

--- a/app/lib/validate.js
+++ b/app/lib/validate.js
@@ -348,6 +348,13 @@ const GUARD_INPUT_SCHEMA = {
   attested_model:  { type: 'string', maxLength: 128 },
   harness:         { type: 'string', maxLength: 64 },
   harness_version: { type: 'string', maxLength: 64 },
+  // Self-test marker (2026-09-09): caller-declared boolean, attribution-only.
+  // Scheduled verification traffic (e.g. the catastrophe-floor regression
+  // probe) is DESIGNED to trip policies, so counting it toward the approval
+  // flood budget produces false-positive flood banners. Excluded from flood
+  // counting in getRecentApprovalCountsByPolicy; never gates a decision —
+  // same posture as the attestation fields above.
+  self_test:      { type: 'boolean' },
 };
 
 // Evidence-first `act` payload — deep validation (caps + per-kind family).

--- a/scripts/catastrophe-floor-probe.mjs
+++ b/scripts/catastrophe-floor-probe.mjs
@@ -89,7 +89,11 @@ for (const test of TEST_CASES) {
         'Content-Type': 'application/json',
         'x-api-key': API_KEY,
       },
-      body: JSON.stringify(test.payload),
+      // Self-test marker (2026-09-09): the probe is DESIGNED to trip policies —
+      // without it the held cases count toward the approval flood budget and
+      // trip a false-positive flood banner. Excluded from flood counting only;
+      // decisions and the ledger are unaffected.
+      body: JSON.stringify({ ...test.payload, self_test: true }),
     });
 
     if (!res.ok) {


### PR DESCRIPTION
## Problem
The catastrophe-floor regression probe is *designed* to trip policies. Its 5 held cases counted toward the per-policy flood budget and tripped a false-positive flood banner on 2026-09-09 ("Approval flood: Catastrophe Floor — 5 interrupts in 15m, per-action pings paused"). A governance product that false-positives daily trains operators to ignore it.

## Fix
- **Guard input schema** (app/lib/validate.js): new optional `self_test` boolean — caller-declared, attribution-only, never gates a decision (same posture as the attestation fields). Rides the field bag into the persisted decision context.
- **Flood counting** (app/lib/repositories/guardrails.repository.ts): `getRecentApprovalCountsByPolicy` excludes rows where the persisted context marks `self_test`, before aggregation. Always applied; the `?include_synthetic=1` escape hatch stays for synthetic families only.
- **Probe** (scripts/catastrophe-floor-probe.mjs): sends `self_test: true` on all 8 cases. Decisions and the ledger are unaffected — only flood counting changes.

## Verification
- 7/7 approval-flood.repository.test.js (2 new: exclusion present; not lifted by includeSynthetic), 22/22 across all flood suites
- L1: prove broke the predicate on purpose — red — restored — green
- eslint clean, tsc --noEmit clean, next build succeeds

## Follow-up considered
The marker is caller-declared, so a hostile client could set it to dodge flood pings. Stakes are low (it only collapses notifications, never approvals; the ledger still records everything). If that becomes a concern, the follow-up is a server-side allowlist of self-test agent IDs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduled verification and self-test traffic is now excluded from approval flood counts, preventing false-positive flood warnings.
  - The exclusion applies consistently, including when synthetic traffic is included in reporting.
  - Self-test markers do not affect guard decisions or ledger records.

- **Tests**
  - Added coverage to verify self-test traffic remains excluded across supported counting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->